### PR TITLE
Refactor date parsing rules

### DIFF
--- a/src/services/date-parser.rules.ts
+++ b/src/services/date-parser.rules.ts
@@ -1,0 +1,16 @@
+import { enUS, ru } from 'date-fns/locale';
+import { Locale } from 'date-fns';
+
+export interface DateFormatRule {
+  format: string;
+  locale: Locale;
+}
+
+export const DATE_PARSER_RULES: DateFormatRule[] = [
+  { format: 'yyyy.MM.dd', locale: enUS },
+  { format: 'd MMMM', locale: ru },
+  { format: 'd MMM yyyy', locale: enUS },
+  { format: 'yyyy-MM-dd', locale: enUS },
+  { format: 'dd.MM', locale: enUS },
+  { format: 'MM/dd', locale: enUS },
+];

--- a/src/services/date-parser.service.ts
+++ b/src/services/date-parser.service.ts
@@ -1,53 +1,54 @@
 import { Injectable } from '@nestjs/common';
-import { parse, isValid, setHours, setMinutes, setSeconds, setMilliseconds } from 'date-fns';
-import { ru, enUS } from 'date-fns/locale';
+import {
+  parse,
+  isValid,
+  setHours,
+  setMinutes,
+  setSeconds,
+  setMilliseconds,
+} from 'date-fns';
+import { DATE_PARSER_RULES } from './date-parser.rules';
 
 interface ParseResult {
-    date: Date | null;
-    cleanContent: string;
+  date: Date | null;
+  cleanContent: string;
 }
 
 @Injectable()
 export class DateParserService {
-    private dateFormats = [
-        { format: 'yyyy.MM.dd', locale: enUS },
-        { format: 'd MMMM', locale: ru },
-        { format: 'd MMM yyyy', locale: enUS },
-        { format: 'yyyy-MM-dd', locale: enUS },
-        { format: 'dd.MM', locale: enUS },
-        { format: 'MM/dd', locale: enUS },
-    ];
+  private dateFormats = DATE_PARSER_RULES;
 
-    extractDateFromFirstLine(text: string): ParseResult {
-        if (!text) return { date: null, cleanContent: '' };
-        
-        const lines = text.split('\n');
-        const firstLine = lines[0].trim();
-        
-        // Пробуем разные форматы
-        for (const { format, locale } of this.dateFormats) {
-            try {
-                const parsedDate = parse(firstLine, format, new Date(), { locale });
-                if (isValid(parsedDate)) {
-                    // Если год не был указан в формате, используем текущий
-                    if (!format.includes('yyyy')) {
-                        parsedDate.setFullYear(new Date().getFullYear());
-                    }
-                    // Устанавливаем время на начало дня в локальной временной зоне
-                    const date = setMilliseconds(setSeconds(setMinutes(setHours(parsedDate, 0), 0), 0), 0);
-                    
-                    // Удаляем первую строку и пустые строки в начале
-                    const cleanContent = lines.slice(1)
-                        .join('\n')
-                        .replace(/^\s+/, '');
+  extractDateFromFirstLine(text: string): ParseResult {
+    if (!text) return { date: null, cleanContent: '' };
 
-                    return { date, cleanContent };
-                }
-            } catch (e) {
-                continue;
-            }
+    const lines = text.split('\n');
+    const firstLine = lines[0].trim();
+
+    // Пробуем разные форматы
+    for (const { format, locale } of this.dateFormats) {
+      try {
+        const parsedDate = parse(firstLine, format, new Date(), { locale });
+        if (isValid(parsedDate)) {
+          // Если год не был указан в формате, используем текущий
+          if (!format.includes('yyyy')) {
+            parsedDate.setFullYear(new Date().getFullYear());
+          }
+          // Устанавливаем время на начало дня в локальной временной зоне
+          const date = setMilliseconds(
+            setSeconds(setMinutes(setHours(parsedDate, 0), 0), 0),
+            0,
+          );
+
+          // Удаляем первую строку и пустые строки в начале
+          const cleanContent = lines.slice(1).join('\n').replace(/^\s+/, '');
+
+          return { date, cleanContent };
         }
-
-        return { date: null, cleanContent: text };
+      } catch (e) {
+        continue;
+      }
     }
-} 
+
+    return { date: null, cleanContent: text };
+  }
+}


### PR DESCRIPTION
## Summary
- centralize date parser rules in `DATE_PARSER_RULES`
- use the shared rules inside `DateParserService`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68702b4001ac832b9ec8f6c8e51faeec