### PR TITLE
Add /task command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Provides Serbian translations for text.
 ### `/history` - Chat History
 Creates an HTML page with all messages from the current chat that are longer than 42 characters. The page is accessible via a secret link that is sent to the chat.
 
+### `/t` or `/task` - Create Todo
+Creates a new todo item with tags, contexts, projects, optional priority and due date.
+
 ### `/help` - Command List
 Shows a list of available commands with brief descriptions.
 

--- a/prisma/migrations/20250711120000_add_content_to_todo/migration.sql
+++ b/prisma/migrations/20250711120000_add_content_to_todo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Todo" ADD COLUMN     "content" TEXT NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Image {
 model Todo {
   id           Int       @id @default(autoincrement())
   key          String
+  content      String    @db.Text
   createdAt    DateTime  @default(now())
   status       String    @default("new")
   completedAt  DateTime?

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -1,0 +1,125 @@
+import { Injectable } from '@nestjs/common';
+import { Context } from 'telegraf';
+import { PrismaService } from '../prisma/prisma.service';
+import { parse, isValid, format, startOfDay, endOfDay } from 'date-fns';
+
+interface ParsedTask {
+    content: string;
+    priority?: string;
+    tags: string[];
+    contexts: string[];
+    projects: string[];
+    dueDate?: Date;
+}
+
+@Injectable()
+export class TaskCommandsService {
+    constructor(private prisma: PrismaService) {}
+
+    async handleTaskCommand(ctx: Context) {
+        const text = this.getCommandText(ctx);
+        if (!text) return;
+        const withoutCommand = text.replace(/^\/(t|task)\s*/, '').trim();
+        const parsed = this.parseTask(withoutCommand);
+        if (!parsed.content) {
+            await ctx.reply('Task text cannot be empty');
+            return;
+        }
+        const key = await this.generateKey();
+        await this.prisma.todo.create({
+            data: {
+                key,
+                content: parsed.content,
+                priority: parsed.priority,
+                dueDate: parsed.dueDate,
+                tags: parsed.tags,
+                contexts: parsed.contexts,
+                projects: parsed.projects,
+            },
+        });
+        await ctx.reply(`Task created with key ${key}`);
+    }
+
+    private getCommandText(ctx: Context): string | undefined {
+        if ('message' in ctx && ctx.message && 'text' in ctx.message) {
+            return ctx.message.text;
+        }
+        if ('channelPost' in ctx && ctx.channelPost && 'text' in ctx.channelPost) {
+            return ctx.channelPost.text;
+        }
+        return undefined;
+    }
+
+    private parseTask(text: string): ParsedTask {
+        const tokens = text.split(/\s+/);
+        const tags: string[] = [];
+        const contexts: string[] = [];
+        const projects: string[] = [];
+        let priority: string | undefined;
+        let dueDate: Date | undefined;
+        const descParts: string[] = [];
+        for (let i = 0; i < tokens.length; i++) {
+            const token = tokens[i];
+            if (/^\([a-zA-Z]\)$/.test(token)) {
+                priority = token.slice(1, 2).toUpperCase();
+                continue;
+            }
+            if (token.startsWith('@')) {
+                tags.push(token.slice(1));
+                continue;
+            }
+            if (token.startsWith('.')) {
+                contexts.push(token.slice(1));
+                continue;
+            }
+            if (token.startsWith('!')) {
+                let project = token.slice(1);
+                while (i + 1 < tokens.length && !tokens[i + 1].startsWith('@') && !tokens[i + 1].startsWith('.') && !tokens[i + 1].startsWith('!') && !tokens[i + 1].startsWith(':') && !/^\([a-zA-Z]\)$/.test(tokens[i + 1])) {
+                    project += ' ' + tokens[i + 1];
+                    i++;
+                }
+                projects.push(project);
+                continue;
+            }
+            if (token.startsWith(':')) {
+                let dateStr = token.slice(1);
+                if (i + 1 < tokens.length && /\d{2}:\d{2}/.test(tokens[i + 1])) {
+                    dateStr += ' ' + tokens[i + 1];
+                    i++;
+                }
+                const parsed = this.parseDueDate(dateStr);
+                if (parsed) {
+                    dueDate = parsed;
+                }
+                continue;
+            }
+            descParts.push(token);
+        }
+        return {
+            content: descParts.join(' ').trim(),
+            priority,
+            tags,
+            contexts,
+            projects,
+            dueDate,
+        };
+    }
+
+    private parseDueDate(text: string): Date | undefined {
+        const formats = ['yyyy.MM.dd HH:mm', 'yyyy.MM.dd'];
+        for (const fmt of formats) {
+            const d = parse(text, fmt, new Date());
+            if (isValid(d)) return d;
+        }
+        return undefined;
+    }
+
+    private async generateKey(): Promise<string> {
+        const today = new Date();
+        const datePart = format(today, 'yyyyMMdd');
+        const count = await this.prisma.todo.count({
+            where: { createdAt: { gte: startOfDay(today), lt: endOfDay(today) } },
+        });
+        return `T-${datePart}-${count + 1}`;
+    }
+}

--- a/src/telegram-bot/telegram-bot.module.ts
+++ b/src/telegram-bot/telegram-bot.module.ts
@@ -9,6 +9,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { StorageService } from '../services/storage.service';
 import { SerbianCommandsService } from './serbian-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
+import { TaskCommandsService } from './task-commands.service';
 
 @Module({
   imports: [ConfigModule, PrismaModule],
@@ -21,6 +22,7 @@ import { HistoryCommandsService } from './history-commands.service';
     StorageService,
     SerbianCommandsService,
     HistoryCommandsService,
+    TaskCommandsService,
   ],
   exports: [TelegramBotService]
 })

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -7,6 +7,7 @@ import { DairyCommandsService } from './dairy-commands.service';
 import { StorageService } from '../services/storage.service';
 import { SerbianCommandsService } from './serbian-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
+import { TaskCommandsService } from './task-commands.service';
 import { Context } from 'telegraf';
 
 describe('TelegramBotService', () => {
@@ -107,6 +108,12 @@ describe('TelegramBotService', () => {
             handleHistoryCommand: jest.fn(),
           },
         },
+        {
+          provide: TaskCommandsService,
+          useValue: {
+            handleTaskCommand: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -143,6 +150,7 @@ describe('TelegramBotService', () => {
       '/help - Show this help message',
       '/history - Chat History',
       '/s - Serbian Translation',
+      '/t or /task - Create Todo item',
     ].join('\n');
     expect(result).toBe(expected);
   });

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -11,6 +11,7 @@ import { DairyCommandsService } from './dairy-commands.service';
 import { StorageService } from '../services/storage.service';
 import { SerbianCommandsService } from './serbian-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
+import { TaskCommandsService } from './task-commands.service';
 
 type TelegramUpdate = 
     | Update.CallbackQueryUpdate 
@@ -29,6 +30,7 @@ export class TelegramBotService {
         private storageService: StorageService,
         private serbianCommands: SerbianCommandsService,
         private historyCommands: HistoryCommandsService,
+        private taskCommands: TaskCommandsService,
     ) {
         const token = this.configService.get<string>('TELEGRAM_BOT_TOKEN');
         if (!token) {
@@ -100,6 +102,12 @@ export class TelegramBotService {
         this.bot.command(['history'], (ctx) => {
             console.log('Получена команда /history:', ctx.message?.text);
             return this.historyCommands.handleHistoryCommand(ctx);
+        });
+
+        // Add the new task command
+        this.bot.command(['t', 'task'], (ctx) => {
+            console.log('Получена команда /t /task:', ctx.message?.text);
+            return this.taskCommands.handleTaskCommand(ctx);
         });
 
         // Help command
@@ -344,6 +352,7 @@ export class TelegramBotService {
             { name: '/dairy or /d', description: 'Dairy Notes' },
             { name: '/history', description: 'Chat History' },
             { name: '/s', description: 'Serbian Translation' },
+            { name: '/t or /task', description: 'Create Todo item' },
             { name: '/help', description: 'Show this help message' },
         ];
         commands.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- implement `/t` (`/task`) command to store tasks in database
- support priority, tags, contexts, due date and projects
- generate unique key per day for each task
- expose new command in help output and README
- add `content` field to Todo model with migration
- test updates for new command

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68702a814600832b8b1e7c2cee7956d0