### PR TITLE
Implement date parser for todo due dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Creates a new todo item.
 - `.context` — specify contexts.
 - `!project` — assign projects (multiword names are allowed).
 - `(A)` — set priority with a letter in parentheses.
-- `:YYYY.MM.DD` or `:YYYY.MM.DD HH:MM` — optional due date. The date portion supports the formats listed above.
+- `:<date>` or `:<date> HH:MM` — optional due date. `<date>` accepts the same formats as in the note examples above.
 
 Example:
 ```

--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TaskCommandsService } from './task-commands.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { DateParserService } from '../services/date-parser.service';
+
+describe('TaskCommandsService', () => {
+  let service: TaskCommandsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TaskCommandsService,
+        DateParserService,
+        {
+          provide: PrismaService,
+          useValue: { todo: { count: jest.fn() } },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TaskCommandsService>(TaskCommandsService);
+  });
+
+  describe('parseDueDate', () => {
+    it('should parse full date and time', () => {
+      const result = (service as any).parseDueDate('2025.07.31 09:30');
+      expect(result).toBeInstanceOf(Date);
+      expect(result?.getFullYear()).toBe(2025);
+      expect(result?.getMonth()).toBe(6); // July
+      expect(result?.getDate()).toBe(31);
+      expect(result?.getHours()).toBe(9);
+      expect(result?.getMinutes()).toBe(30);
+    });
+
+    it('should parse date without time using parser rules', () => {
+      const result = (service as any).parseDueDate('2 января');
+      const year = new Date().getFullYear();
+      expect(result).toBeInstanceOf(Date);
+      expect(result?.getFullYear()).toBe(year);
+      expect(result?.getMonth()).toBe(0);
+      expect(result?.getDate()).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- rework task commands to use `DateParserService`
- add tests for todo due date parsing
- document new due date behavior in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870e3b9cad4832ba17648c4a5f61033