### PR TITLE
Add todo editing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Creates a new todo item.
 - `(A)` — set priority with a letter in parentheses.
 - `:<date>` or `:<date> HH:MM` — optional due date. `<date>` accepts the same formats as in the note examples above.
 
+To update an existing task, start the command with its key:
+`/t T-20250710-3 ...`. New tags and contexts are appended while
+projects and due dates are replaced. The text part can be empty.
+Use `-canceled`, `-done`, `-in-progress` or `-started` to set the status.
+
 Example:
 ```
 /task (B) @work .office !Big Project :2025.07.31 09:00 Prepare report

--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -41,4 +41,55 @@ describe('TaskCommandsService', () => {
       expect(result?.getDate()).toBe(2);
     });
   });
+
+  describe('parseTask', () => {
+    it('should parse status token', () => {
+      const result = (service as any).parseTask('-done @tag example');
+      expect(result.status).toBe('done');
+      expect(result.tags).toEqual(['tag']);
+      expect(result.content).toBe('example');
+    });
+  });
+
+  describe('handleTaskCommand edit', () => {
+    it('should copy existing task and apply updates', async () => {
+      const mockPrisma = {
+        todo: {
+          count: jest.fn(),
+          findFirst: jest.fn().mockResolvedValue({
+            key: 'T-20250710-3',
+            content: 'old',
+            priority: 'A',
+            dueDate: undefined,
+            tags: ['work'],
+            contexts: ['home'],
+            projects: ['Proj'],
+            status: 'new',
+          }),
+          create: jest.fn(),
+        },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [TaskCommandsService, DateParserService, { provide: PrismaService, useValue: mockPrisma }],
+      }).compile();
+
+      const svc = module.get<TaskCommandsService>(TaskCommandsService);
+      const ctx: any = { message: { text: '/t T-20250710-3 -done @x .y !New :2025.07.31 new text' }, reply: jest.fn() };
+      await svc.handleTaskCommand(ctx);
+      expect(mockPrisma.todo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            key: 'T-20250710-3',
+            status: 'done',
+            tags: ['work', 'x'],
+            contexts: ['home', 'y'],
+            projects: ['New'],
+            content: 'new text',
+          }),
+        }),
+      );
+      expect(ctx.reply).toHaveBeenCalledWith('Task T-20250710-3 updated');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- allow `/t KEY` to edit tasks using the same parsing as creation
- support status flags `-canceled`, `-done`, `-in-progress`, `-started`
- add helper to copy the previous task version and append tags/contexts
- document editing behaviour in README
- expand unit tests for task command parsing and editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68727ae36938832b967d9891e8203ce9