### PR TITLE
Add /tl task list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Example:
 /task (B) @work .office !Big Project :2025.07.31 09:00 Prepare report
 ```
 
+### `/tl`
+Lists unfinished todo items. You can filter by the same `@tag`, `.context` and `!project` tokens as in `/task`.
+
+Example:
+```
+/tl @work .office
+```
+
 ### `/help`
 Shows a list of all available commands.
 

--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -51,6 +51,16 @@ describe('TaskCommandsService', () => {
     });
   });
 
+  describe('parseFilters', () => {
+    it('should parse tags contexts and projects', () => {
+      const result = (service as any).parseFilters('@a .b !Proj rest');
+      expect(result.tags).toEqual(['a']);
+      expect(result.contexts).toEqual(['b']);
+      expect(result.projects).toEqual(['Proj rest']);
+      expect(result.remaining).toEqual([]);
+    });
+  });
+
   describe('handleTaskCommand edit', () => {
     it('should copy existing task and apply updates', async () => {
       const mockPrisma = {

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -112,6 +112,7 @@ describe('TelegramBotService', () => {
           provide: TaskCommandsService,
           useValue: {
             handleTaskCommand: jest.fn(),
+            handleListCommand: jest.fn(),
           },
         },
       ],
@@ -151,6 +152,7 @@ describe('TelegramBotService', () => {
       '/history - Chat History',
       '/s - Serbian Translation',
       '/t or /task - Create Todo item',
+      '/tl - List Todo items',
     ].join('\n');
     expect(result).toBe(expected);
   });

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -110,6 +110,12 @@ export class TelegramBotService {
             return this.taskCommands.handleTaskCommand(ctx);
         });
 
+        // Task list command
+        this.bot.command(['tl'], (ctx) => {
+            console.log('Получена команда /tl:', ctx.message?.text);
+            return this.taskCommands.handleListCommand(ctx);
+        });
+
         // Help command
         this.bot.command(['help'], (ctx) => {
             console.log('Получена команда /help');
@@ -353,6 +359,7 @@ export class TelegramBotService {
             { name: '/history', description: 'Chat History' },
             { name: '/s', description: 'Serbian Translation' },
             { name: '/t or /task', description: 'Create Todo item' },
+            { name: '/tl', description: 'List Todo items' },
             { name: '/help', description: 'Show this help message' },
         ];
         commands.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- add `/tl` command to list unfinished tasks
- extract shared filter parser for task commands
- support filtering by tags, contexts, and projects
- register command in bot and update help message
- document new command and extend unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873532b7a18832b9290004dba7f5ac9