### PR TITLE
Add format hint to /t command

### DIFF
--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -102,4 +102,18 @@ describe('TaskCommandsService', () => {
       expect(ctx.reply).toHaveBeenCalledWith('Task T-20250710-3 updated');
     });
   });
+
+  describe('handleTaskCommand empty', () => {
+    it('should show format message', async () => {
+      const mockPrisma = { todo: { count: jest.fn() } };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [TaskCommandsService, DateParserService, { provide: PrismaService, useValue: mockPrisma }],
+      }).compile();
+
+      const svc = module.get<TaskCommandsService>(TaskCommandsService);
+      const ctx: any = { message: { text: '/t' }, reply: jest.fn() };
+      await svc.handleTaskCommand(ctx);
+      expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining('Format:'));
+    });
+  });
 });

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -25,6 +25,10 @@ export class TaskCommandsService {
         const text = this.getCommandText(ctx);
         if (!text) return;
         const withoutCommand = text.replace(/^\/(t|task)\s*/, '').trim();
+        if (!withoutCommand) {
+            await ctx.reply(this.getTaskFormatMessage());
+            return;
+        }
         const parts = withoutCommand.split(/\s+/);
         let key: string | undefined;
         if (parts.length && /^T-\d{8}-\d+$/.test(parts[0])) {
@@ -254,5 +258,13 @@ export class TaskCommandsService {
             return line;
         });
         await ctx.reply(lines.join('\n'));
+    }
+
+    private getTaskFormatMessage(): string {
+        return [
+            'Format:',
+            '/t [T-YYYYMMDD-N] (-status) @tag .context !project (A) :<date> text',
+            'Example: /task (B) @work .office !Big Project :2025.07.31 09:00 Prepare report'
+        ].join('\n');
     }
 }


### PR DESCRIPTION
## Summary
- show task format when `/t` or `/task` are invoked without arguments
- test that empty invocation responds with format hint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874b08bec7c832bb0609d6fea464ebd