### PR TITLE
Add /th command for task history export

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Example:
 /tl @work .office
 ```
 
+### `/th`
+Generates an HTML page with all tasks and their history stored on DigitalOcean Spaces.
+Unfinished tasks are sorted by due date and key, finished tasks by creation date.
+
+
 ### `/help`
 Shows a list of all available commands.
 

--- a/src/telegram-bot/task-history-commands.service.spec.ts
+++ b/src/telegram-bot/task-history-commands.service.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TaskHistoryCommandsService } from './task-history-commands.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { StorageService } from '../services/storage.service';
+
+describe('TaskHistoryCommandsService', () => {
+  let service: TaskHistoryCommandsService;
+  const mockPrismaService = {
+    todo: {
+      findMany: jest.fn(),
+    },
+  };
+  const mockStorageService = {
+    uploadFileWithKey: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TaskHistoryCommandsService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: StorageService, useValue: mockStorageService },
+      ],
+    }).compile();
+
+    service = module.get<TaskHistoryCommandsService>(TaskHistoryCommandsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should reply when no tasks', async () => {
+    const ctx: any = { reply: jest.fn() };
+    mockPrismaService.todo.findMany.mockResolvedValue([]);
+    await service.handleTaskHistoryCommand(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith('No tasks found');
+  });
+});

--- a/src/telegram-bot/telegram-bot.module.ts
+++ b/src/telegram-bot/telegram-bot.module.ts
@@ -10,6 +10,7 @@ import { StorageService } from '../services/storage.service';
 import { SerbianCommandsService } from './serbian-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
+import { TaskHistoryCommandsService } from './task-history-commands.service';
 
 @Module({
   imports: [ConfigModule, PrismaModule],
@@ -23,6 +24,7 @@ import { TaskCommandsService } from './task-commands.service';
     SerbianCommandsService,
     HistoryCommandsService,
     TaskCommandsService,
+    TaskHistoryCommandsService,
   ],
   exports: [TelegramBotService]
 })

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -8,6 +8,7 @@ import { StorageService } from '../services/storage.service';
 import { SerbianCommandsService } from './serbian-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
+import { TaskHistoryCommandsService } from './task-history-commands.service';
 import { Context } from 'telegraf';
 
 describe('TelegramBotService', () => {
@@ -115,6 +116,12 @@ describe('TelegramBotService', () => {
             handleListCommand: jest.fn(),
           },
         },
+        {
+          provide: TaskHistoryCommandsService,
+          useValue: {
+            handleTaskHistoryCommand: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -152,6 +159,7 @@ describe('TelegramBotService', () => {
       '/history - Chat History',
       '/s - Serbian Translation',
       '/t or /task - Create Todo item',
+      '/th - Tasks HTML export',
       '/tl - List Todo items',
     ].join('\n');
     expect(result).toBe(expected);

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -12,6 +12,7 @@ import { StorageService } from '../services/storage.service';
 import { SerbianCommandsService } from './serbian-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
+import { TaskHistoryCommandsService } from './task-history-commands.service';
 
 type TelegramUpdate = 
     | Update.CallbackQueryUpdate 
@@ -31,6 +32,7 @@ export class TelegramBotService {
         private serbianCommands: SerbianCommandsService,
         private historyCommands: HistoryCommandsService,
         private taskCommands: TaskCommandsService,
+        private taskHistoryCommands: TaskHistoryCommandsService,
     ) {
         const token = this.configService.get<string>('TELEGRAM_BOT_TOKEN');
         if (!token) {
@@ -114,6 +116,12 @@ export class TelegramBotService {
         this.bot.command(['tl'], (ctx) => {
             console.log('Получена команда /tl:', ctx.message?.text);
             return this.taskCommands.handleListCommand(ctx);
+        });
+
+        // Task history HTML command
+        this.bot.command(['th'], (ctx) => {
+            console.log('Получена команда /th:', ctx.message?.text);
+            return this.taskHistoryCommands.handleTaskHistoryCommand(ctx);
         });
 
         // Help command
@@ -360,6 +368,7 @@ export class TelegramBotService {
             { name: '/s', description: 'Serbian Translation' },
             { name: '/t or /task', description: 'Create Todo item' },
             { name: '/tl', description: 'List Todo items' },
+            { name: '/th', description: 'Tasks HTML export' },
             { name: '/help', description: 'Show this help message' },
         ];
         commands.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- export tasks with history to DigitalOcean Spaces via `/th`
- wire up `TaskHistoryCommandsService` in the Telegram bot
- document new command in README
- cover help message and new service with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68750a0e60b0832b91b8a1396b8126e3