### PR TITLE
Fix README formatting for th command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ Example:
 
 ### `/th`
 Generates an HTML page with all tasks and their history stored on DigitalOcean Spaces.
+
 Tasks are organized into three categories:
 - **Unfinished**: Active tasks sorted by due date and key
-- **Snoozed**: Tasks that are currently snoozed, sorted by snooze expiration date and key  
+- **Snoozed**: Tasks that are currently snoozed, sorted by snooze expiration date and key
 - **Finished**: Completed or canceled tasks sorted by creation date
 
 The snoozed until date is displayed for snoozed tasks.

--- a/src/telegram-bot/task-history-commands.service.ts
+++ b/src/telegram-bot/task-history-commands.service.ts
@@ -126,7 +126,7 @@ export class TaskHistoryCommandsService {
                 }
                 html += '</li>';
             }
-            html += '</ul></div></div>';
+            html += '</ul></div></div>\n<br/>';
         }
         return html;
     }


### PR DESCRIPTION
## Summary
- add missing blank line in the `/th` command documentation
- add blank line between tasks when generating `/th` HTML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687742d76fc8832b947f26214bcf1c7e