### PR TITLE
Add zero-padded task keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Creates a new todo item.
 - `:<date>` or `:<date> HH:MM` — optional due date. `<date>` accepts the same formats as in the note examples above.
 
 To update an existing task, start the command with its key:
-`/t T-20250710-3 ...`. New tags and contexts are appended while
+`/t T-20250710-03 ...`. New tags and contexts are appended while
 projects and due dates are replaced. The text part can be empty.
 Use `-canceled`, `-done`, `-in-progress`, `-started`, or `-snoozed[days]` (e.g., `-snoozed4` or `-snoozed 4`) to set the status.
 Snoozed tasks are hidden from `/tl` until their snooze period expires.

--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TaskCommandsService } from './task-commands.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { DateParserService } from '../services/date-parser.service';
+import { format } from 'date-fns';
 
 describe('TaskCommandsService', () => {
   let service: TaskCommandsService;
@@ -89,6 +90,21 @@ describe('TaskCommandsService', () => {
       expect(result.contexts).toEqual(['b']);
       expect(result.projects).toEqual(['Proj rest']);
       expect(result.remaining).toEqual([]);
+    });
+  });
+
+  describe('generateKey', () => {
+    it('pads single digit counts', async () => {
+      const today = new Date();
+      const datePart = format(today, 'yyyyMMdd');
+      const mockPrisma = { todo: { count: jest.fn().mockResolvedValue(0) } };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [TaskCommandsService, DateParserService, { provide: PrismaService, useValue: mockPrisma }],
+      }).compile();
+
+      const svc = module.get<TaskCommandsService>(TaskCommandsService);
+      const key = await (svc as any).generateKey(123);
+      expect(key).toBe(`T-${datePart}-01`);
     });
   });
 

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -236,12 +236,14 @@ export class TaskCommandsService {
         const today = new Date();
         const datePart = format(today, 'yyyyMMdd');
         const count = await this.prisma.todo.count({
-            where: { 
+            where: {
                 createdAt: { gte: startOfDay(today), lt: endOfDay(today) },
                 chatId: chatId
             },
         });
-        return `T-${datePart}-${count + 1}`;
+        const index = count + 1;
+        const indexStr = index.toString().padStart(2, '0');
+        return `T-${datePart}-${indexStr}`;
     }
 
     async handleListCommand(ctx: Context) {
@@ -317,10 +319,10 @@ export class TaskCommandsService {
     private getTaskFormatMessage(): string {
         return [
             'Format:',
-            '/t [T-YYYYMMDD-N] (-status) @tag .context !project (A) :<date> text',
+            '/t [T-YYYYMMDD-NN] (-status) @tag .context !project (A) :<date> text',
             'Status options: -done, -canceled, -in-progress, -started, -snoozed[days] or -snoozed [days]',
             'Example: /task (B) @work .office !Big Project :2025.07.31 09:00 Prepare report',
-            'Snooze examples: /task T-20250715-1 -snoozed4 or /task T-20250715-1 -snoozed 4'
+            'Snooze examples: /task T-20250715-01 -snoozed4 or /task T-20250715-01 -snoozed 4'
         ].join('\n');
     }
 }


### PR DESCRIPTION
## Summary
- format new task keys with a leading zero when count < 10
- update help text and docs for new key format
- test generateKey to ensure padding logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68774fe1ba00832b98e36f7a396b46c6