### PR TITLE
Add image descriptions to history export

### DIFF
--- a/src/telegram-bot/history-commands.service.ts
+++ b/src/telegram-bot/history-commands.service.ts
@@ -114,6 +114,11 @@ export class HistoryCommandsService {
             border-radius: 8px;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
         }
+        .image-description {
+            margin-top: 4px;
+            font-size: 0.9em;
+            color: #555;
+        }
         .stats {
             background: white;
             padding: 15px;
@@ -153,9 +158,11 @@ export class HistoryCommandsService {
             
             if (message.images && message.images.length > 0) {
                 message.images.forEach((image: any) => {
+                    const description = image.description ? this.escapeHtml(image.description) : 'Изображение';
                     html += `
         <div class="message-image">
-            <img src="${image.url}" alt="Изображение" />
+            <img src="${image.url}" alt="${description}" />
+            ${image.description ? `<div class="image-description">${description}</div>` : ''}
         </div>
 `;
                 });

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { DateParserService } from '../services/date-parser.service';
 import { DairyCommandsService } from './dairy-commands.service';
 import { StorageService } from '../services/storage.service';
+import { LlmService } from '../services/llm.service';
 import { SerbianCommandsService } from './serbian-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
@@ -92,9 +93,15 @@ describe('TelegramBotService', () => {
         {
           provide: StorageService,
           useValue: {
-            uploadFile: jest.fn().mockImplementation((buffer, mimeType, chatId) => 
+            uploadFile: jest.fn().mockImplementation((buffer, mimeType, chatId) =>
               Promise.resolve(`https://example.com/chats/${chatId}/images/mock-uuid`)
             ),
+          },
+        },
+        {
+          provide: LlmService,
+          useValue: {
+            describeImage: jest.fn().mockResolvedValue('test description'),
           },
         },
         {


### PR DESCRIPTION
## Summary
- include image descriptions when generating chat history
- show optional caption below each image in history export
- mock `LlmService` in `TelegramBotService` tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877787d0c5c832b9fd9cc1be891f749