### PR TITLE
Restore interactive collage command

### DIFF
--- a/src/telegram-bot/collage-commands.service.spec.ts
+++ b/src/telegram-bot/collage-commands.service.spec.ts
@@ -65,6 +65,10 @@ describe('CollageCommandsService', () => {
       ],
     }).compile();
 
+    global.fetch = jest.fn().mockResolvedValue({
+      arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('img')),
+    }) as any;
+
     service = module.get<CollageCommandsService>(CollageCommandsService);
     prismaService = module.get<PrismaService>(PrismaService);
     storageService = module.get<StorageService>(StorageService);

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -134,6 +134,11 @@ describe('TelegramBotService', () => {
           provide: CollageCommandsService,
           useValue: {
             handleCollageCommand: jest.fn(),
+            startConversation: jest.fn(),
+            addImage: jest.fn(),
+            cancel: jest.fn(),
+            generate: jest.fn(),
+            isActive: jest.fn().mockReturnValue(false),
           },
         },
       ],
@@ -168,8 +173,8 @@ describe('TelegramBotService', () => {
   it('should return sorted help message', () => {
     const result = (service as any).getHelpMessage();
     const expected = [
-      '/c or /collage - Create collage from message images',
-      '/dairy or /d - Dairy Notes',
+      '/c or /collage - Create image collage',
+      '/d or /dairy - Dairy Notes',
       '/help - Show this help message',
       '/history - Chat History',
       '/s - Serbian Translation',


### PR DESCRIPTION
## Summary
- implement interactive /collage flow in `CollageCommandsService`
- wire collage session handlers in `TelegramBotService`
- update tests for new collage behaviour and mock fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a69996130832b8e77a7019be8cdbf