### PR TITLE
Add /qa command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This project includes a Telegram bot with several useful commands. Notes are saved automatically from any text or photo you send to the bot.
 
 ### Creating a new note
+
 Send a message or a photo caption to save a diary note for today. To store a note for a different date, start the first line with the desired date. The bot understands several common date formats.
 
 ```
@@ -22,39 +23,50 @@ Supported date formats:
 If you omit the date, the note is saved with today's date.
 
 ### `/d` or `/dairy`
+
 Retrieves diary entries for a specific date.
+
 - **date** (optional) — use `DD.MM.YYYY` to show a single day or `DD.MM`/`DD month` to see the same day across years.
 
 Example:
+
 ```
 /d 25.03.2024
 ```
 
 ### `/s`
+
 Provides Serbian translations. Only works in private chats.
+
 - **text** — Serbian word or phrase.
 
 Example:
+
 ```
 /s zdravo
 ```
 
 ### `/history`
+
 Generates an HTML page with all messages longer than 42 characters.
 
 **Features:**
+
 - Filters messages longer than 42 characters
 - Generates a beautiful HTML page with chat history
 - Provides a secret GUID-based link
 - Includes message dates and images
 
 Example:
+
 ```
 /history
 ```
 
 ### `/t` or `/task`
+
 Creates a new todo item.
+
 - **content** — description of the todo item.
 - `@tag` — add tags.
 - `.context` — specify contexts.
@@ -69,22 +81,27 @@ Use `-canceled`, `-done`, `-in-progress`, `-started`, or `-snoozed[days]` (e.g.,
 Snoozed tasks are hidden from `/tl` until their snooze period expires.
 
 Example:
+
 ```
 /task (B) @work .office !Big Project :2025.07.31 09:00 Prepare report
 ```
 
 ### `/tl`
+
 Lists unfinished todo items. You can filter by the same `@tag`, `.context` and `!project` tokens as in `/task`.
 
 Example:
+
 ```
 /tl @work .office
 ```
 
 ### `/th`
+
 Generates an HTML page with all tasks and their history stored on DigitalOcean Spaces.
 
 Tasks are organized into three categories:
+
 - **Unfinished**: Active tasks sorted by due date and key
 - **Snoozed**: Tasks that are currently snoozed, sorted by snooze expiration date and key
 - **Finished**: Completed or canceled tasks sorted by creation date
@@ -92,8 +109,18 @@ Tasks are organized into three categories:
 The snoozed until date is displayed for snoozed tasks.
 History lines show only what changed instead of repeating the full task text.
 
+### `/qa`
+
+Adds a new question for the current chat.
+
+Example:
+
+```
+/qa How many apples do you have?
+```
 
 ### `/help`
+
 Shows a list of all available commands.
 
 ## Project setup

--- a/src/telegram-bot/qa-commands.service.ts
+++ b/src/telegram-bot/qa-commands.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { Context } from 'telegraf';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class QaCommandsService {
+  constructor(private prisma: PrismaService) {}
+
+  async handleQaCommand(ctx: Context) {
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+
+    const messageText = this.getCommandText(ctx);
+    if (!messageText) return;
+
+    const questionText = messageText.replace(/^\/qa\s*/, '').trim();
+    if (!questionText) {
+      await ctx.reply('Please provide question text after the command');
+      return;
+    }
+
+    try {
+      await this.prisma.question.create({
+        data: {
+          chatId,
+          questionText,
+          type: 'text',
+        },
+      });
+      await ctx.reply('Question added');
+    } catch (error) {
+      console.error('Error saving question:', error);
+      await ctx.reply('Error saving question');
+    }
+  }
+
+  private getCommandText(ctx: Context): string | undefined {
+    if ('message' in ctx && ctx.message && 'text' in ctx.message) {
+      return ctx.message.text;
+    }
+    if ('channelPost' in ctx && ctx.channelPost && 'text' in ctx.channelPost) {
+      return ctx.channelPost.text;
+    }
+    return undefined;
+  }
+}

--- a/src/telegram-bot/telegram-bot.module.ts
+++ b/src/telegram-bot/telegram-bot.module.ts
@@ -11,6 +11,7 @@ import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
 import { TaskHistoryCommandsService } from './task-history-commands.service';
 import { CollageCommandsService } from './collage-commands.service';
+import { QaCommandsService } from './qa-commands.service';
 
 @Module({
   imports: [ConfigModule, PrismaModule, ServicesModule],
@@ -24,8 +25,9 @@ import { CollageCommandsService } from './collage-commands.service';
     TaskCommandsService,
     TaskHistoryCommandsService,
     CollageCommandsService,
+    QaCommandsService,
   ],
-  exports: [TelegramBotService]
+  exports: [TelegramBotService],
 })
 export class TelegramBotModule implements OnModuleInit, OnModuleDestroy {
   constructor(private botService: TelegramBotService) {}

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -11,6 +11,7 @@ import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
 import { TaskHistoryCommandsService } from './task-history-commands.service';
 import { CollageCommandsService } from './collage-commands.service';
+import { QaCommandsService } from './qa-commands.service';
 import { Context } from 'telegraf';
 
 describe('TelegramBotService', () => {
@@ -19,15 +20,17 @@ describe('TelegramBotService', () => {
   const mockContext = {
     message: {
       text: 'test message',
-      photo: [{
-        file_id: 'test-file-id',
-        width: 100,
-        height: 100
-      }],
-      caption: 'test caption'
+      photo: [
+        {
+          file_id: 'test-file-id',
+          width: 100,
+          height: 100,
+        },
+      ],
+      caption: 'test caption',
     },
     chat: {
-      id: 123456
+      id: 123456,
     },
     telegram: {
       getFile: jest.fn().mockResolvedValue({ file_path: 'test/path' }),
@@ -38,7 +41,7 @@ describe('TelegramBotService', () => {
       id: 123,
       is_bot: true,
       first_name: 'TestBot',
-      username: 'test_bot'
+      username: 'test_bot',
     },
     tg: {
       getFile: jest.fn().mockResolvedValue({ file_path: 'test/path' }),
@@ -47,8 +50,8 @@ describe('TelegramBotService', () => {
       id: 123,
       is_bot: true,
       first_name: 'TestBot',
-      username: 'test_bot'
-    }
+      username: 'test_bot',
+    },
   } as unknown as Context;
 
   beforeEach(async () => {
@@ -67,7 +70,7 @@ describe('TelegramBotService', () => {
             note: {
               create: jest.fn().mockResolvedValue({
                 id: 1,
-                content: 'test content'
+                content: 'test content',
               }),
               findMany: jest.fn(),
             },
@@ -81,7 +84,7 @@ describe('TelegramBotService', () => {
           useValue: {
             extractDateFromFirstLine: jest.fn().mockReturnValue({
               date: new Date(),
-              cleanContent: 'test content'
+              cleanContent: 'test content',
             }),
           },
         },
@@ -94,9 +97,13 @@ describe('TelegramBotService', () => {
         {
           provide: StorageService,
           useValue: {
-            uploadFile: jest.fn().mockImplementation((buffer, mimeType, chatId) =>
-              Promise.resolve(`https://example.com/chats/${chatId}/images/mock-uuid`)
-            ),
+            uploadFile: jest
+              .fn()
+              .mockImplementation((buffer, mimeType, chatId) =>
+                Promise.resolve(
+                  `https://example.com/chats/${chatId}/images/mock-uuid`,
+                ),
+              ),
           },
         },
         {
@@ -141,6 +148,12 @@ describe('TelegramBotService', () => {
             isActive: jest.fn().mockReturnValue(false),
           },
         },
+        {
+          provide: QaCommandsService,
+          useValue: {
+            handleQaCommand: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -161,9 +174,9 @@ describe('TelegramBotService', () => {
       ...mockContext,
       channelPost: {
         ...mockContext.message,
-        chat: { id: -1001234567890, type: 'channel', title: 'Test Channel' }
+        chat: { id: -1001234567890, type: 'channel', title: 'Test Channel' },
       },
-      updateType: 'channel_post'
+      updateType: 'channel_post',
     } as unknown as Context;
 
     await service.handleIncomingPhoto(channelContext);
@@ -177,6 +190,7 @@ describe('TelegramBotService', () => {
       '/d or /dairy - Dairy Notes',
       '/help - Show this help message',
       '/history - Chat History',
+      '/qa - Add question',
       '/s - Serbian Translation',
       '/t or /task - Create Todo item',
       '/th - Tasks HTML export',

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -15,449 +15,512 @@ import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
 import { TaskHistoryCommandsService } from './task-history-commands.service';
 import { CollageCommandsService } from './collage-commands.service';
+import { QaCommandsService } from './qa-commands.service';
 
-type TelegramUpdate = 
-    | Update.CallbackQueryUpdate 
-    | Update.MessageUpdate 
-    | { channel_post: Message.TextMessage };
+type TelegramUpdate =
+  | Update.CallbackQueryUpdate
+  | Update.MessageUpdate
+  | { channel_post: Message.TextMessage };
 
 @Injectable()
 export class TelegramBotService {
-    private bot: Telegraf<Context>;
-    
-    // Маппинг каналов к создателям (дополнительный механизм)
-    private channelCreatorMapping: Map<number, number> = new Map();
+  private bot: Telegraf<Context>;
 
-    constructor(
-        private configService: ConfigService,
-        private prisma: PrismaService,
-        private dateParser: DateParserService,
-        private dairyCommands: DairyCommandsService,
-        private storageService: StorageService,
-        private llmService: LlmService,
-        private serbianCommands: SerbianCommandsService,
-        private historyCommands: HistoryCommandsService,
-        private taskCommands: TaskCommandsService,
-        private taskHistoryCommands: TaskHistoryCommandsService,
-        private collageCommands: CollageCommandsService,
-    ) {
-        const token = this.configService.get<string>('TELEGRAM_BOT_TOKEN');
-        if (!token) {
-            throw new Error('TELEGRAM_BOT_TOKEN is not defined');
-        }
-        this.bot = new Telegraf<Context>(token);
+  // Маппинг каналов к создателям (дополнительный механизм)
+  private channelCreatorMapping: Map<number, number> = new Map();
 
-        // Добавляем middleware для логирования
-        this.bot.use((ctx, next) => {
-            const updateType = ctx.updateType;
-            const chatType = ctx.chat?.type;
-            console.log(`Получено обновление типа [${updateType}] из чата типа [${chatType}]`);
-            return next();
-        });
+  constructor(
+    private configService: ConfigService,
+    private prisma: PrismaService,
+    private dateParser: DateParserService,
+    private dairyCommands: DairyCommandsService,
+    private storageService: StorageService,
+    private llmService: LlmService,
+    private serbianCommands: SerbianCommandsService,
+    private historyCommands: HistoryCommandsService,
+    private taskCommands: TaskCommandsService,
+    private taskHistoryCommands: TaskHistoryCommandsService,
+    private collageCommands: CollageCommandsService,
+    private qaCommands: QaCommandsService,
+  ) {
+    const token = this.configService.get<string>('TELEGRAM_BOT_TOKEN');
+    if (!token) {
+      throw new Error('TELEGRAM_BOT_TOKEN is not defined');
+    }
+    this.bot = new Telegraf<Context>(token);
 
-        this.setupCommands();
-        
-        // Инициализируем маппинг для известных каналов
-        // VlandivirTestChannel -> creator ID 150847737
-        this.addChannelCreatorMapping(-1001594248060, 150847737);
-        this.addChannelCreatorMapping(-1002251325012, 150847737);
-        this.addChannelCreatorMapping(-1002259110541, 150847737);
+    // Добавляем middleware для логирования
+    this.bot.use((ctx, next) => {
+      const updateType = ctx.updateType;
+      const chatType = ctx.chat?.type;
+      console.log(
+        `Получено обновление типа [${updateType}] из чата типа [${chatType}]`,
+      );
+      return next();
+    });
+
+    this.setupCommands();
+
+    // Инициализируем маппинг для известных каналов
+    // VlandivirTestChannel -> creator ID 150847737
+    this.addChannelCreatorMapping(-1001594248060, 150847737);
+    this.addChannelCreatorMapping(-1002251325012, 150847737);
+    this.addChannelCreatorMapping(-1002259110541, 150847737);
+  }
+
+  async startBot() {
+    // Заменяем launch() на webhook
+    const webhookUrl = this.configService.get<string>(
+      'VLANDIVIR_2025_WEBHOOK_URL',
+    ); // например, https://your-domain.com/telegram-bot
+    if (!webhookUrl) {
+      throw new Error('VLANDIVIR_2025_WEBHOOK_URL is not defined');
     }
 
-    async startBot() {
-        // Заменяем launch() на webhook
-        const webhookUrl = this.configService.get<string>('VLANDIVIR_2025_WEBHOOK_URL'); // например, https://your-domain.com/telegram-bot
-        if (!webhookUrl) {
-            throw new Error('VLANDIVIR_2025_WEBHOOK_URL is not defined');
-        }
+    // Устанавливаем webhook вместо запуска long polling
+    await this.bot.telegram.setWebhook(webhookUrl);
+    console.log('Telegram bot webhook set to:', webhookUrl);
+  }
 
-        // Устанавливаем webhook вместо запуска long polling
-        await this.bot.telegram.setWebhook(webhookUrl);
-        console.log('Telegram bot webhook set to:', webhookUrl);
-    }
+  async stopBot() {
+    await this.bot.stop();
+  }
 
-    async stopBot() {
-        await this.bot.stop();
-    }
+  private setupCommands() {
+    // Регистрируем команды для личных чатов и групп
+    this.bot.command(['dairy', 'd'], (ctx) => {
+      console.log('Получена команда /dairy /d:', ctx.message?.text);
+      return this.dairyCommands.handleDairyCommand(ctx);
+    });
 
-    private setupCommands() {
-        // Регистрируем команды для личных чатов и групп
-        this.bot.command(['dairy', 'd'], (ctx) => {
-            console.log('Получена команда /dairy /d:', ctx.message?.text);
-            return this.dairyCommands.handleDairyCommand(ctx);
-        });
+    // Регистрируем те же команды для каналов
+    this.bot.on(channelPost('text'), async (ctx) => {
+      console.log('Получено сообщение из канала:', {
+        text: ctx.channelPost.text,
+        from: ctx.channelPost.from,
+        chat: ctx.chat,
+      });
 
-        // Регистрируем те же команды для каналов
-        this.bot.on(channelPost('text'), async (ctx) => {
-            console.log('Получено сообщение из канала:', {
-                text: ctx.channelPost.text,
-                from: ctx.channelPost.from,
-                chat: ctx.chat
-            });
-            
-            if (ctx.channelPost.text.startsWith('/d') || ctx.channelPost.text.startsWith('/dairy')) {
-                console.log('Обработка команды /dairy /d из канала');
-                await this.dairyCommands.handleDairyCommand(ctx);
-                return;
-            }
-            const update = {
-                channel_post: ctx.channelPost
-            } as TelegramUpdate;
-            await this.handleIncomingMessage(ctx.chat.id, update, true);
-        });
+      if (
+        ctx.channelPost.text.startsWith('/d') ||
+        ctx.channelPost.text.startsWith('/dairy')
+      ) {
+        console.log('Обработка команды /dairy /d из канала');
+        await this.dairyCommands.handleDairyCommand(ctx);
+        return;
+      }
+      const update = {
+        channel_post: ctx.channelPost,
+      } as TelegramUpdate;
+      await this.handleIncomingMessage(ctx.chat.id, update, true);
+    });
 
-        // Add the new Serbian translation command
-        this.bot.command(['s'], (ctx) => {
-            console.log('Получена команда /s:', ctx.message?.text);
-            return this.serbianCommands.handleSerbianCommand(ctx);
-        });
+    // Add the new Serbian translation command
+    this.bot.command(['s'], (ctx) => {
+      console.log('Получена команда /s:', ctx.message?.text);
+      return this.serbianCommands.handleSerbianCommand(ctx);
+    });
 
-        // Add the new history command
-        this.bot.command(['history'], (ctx) => {
-            console.log('Получена команда /history:', ctx.message?.text);
-            return this.historyCommands.handleHistoryCommand(ctx);
-        });
+    // Add the new history command
+    this.bot.command(['history'], (ctx) => {
+      console.log('Получена команда /history:', ctx.message?.text);
+      return this.historyCommands.handleHistoryCommand(ctx);
+    });
 
-        // Add the new task command
-        this.bot.command(['t', 'task'], (ctx) => {
-            console.log('Получена команда /t /task:', ctx.message?.text);
-            return this.taskCommands.handleTaskCommand(ctx);
-        });
+    // Add the new task command
+    this.bot.command(['t', 'task'], (ctx) => {
+      console.log('Получена команда /t /task:', ctx.message?.text);
+      return this.taskCommands.handleTaskCommand(ctx);
+    });
 
-        // Task list command
-        this.bot.command(['tl'], (ctx) => {
-            console.log('Получена команда /tl:', ctx.message?.text);
-            return this.taskCommands.handleListCommand(ctx);
-        });
+    // Task list command
+    this.bot.command(['tl'], (ctx) => {
+      console.log('Получена команда /tl:', ctx.message?.text);
+      return this.taskCommands.handleListCommand(ctx);
+    });
 
-        // Task history HTML command
-        this.bot.command(['th'], (ctx) => {
-            console.log('Получена команда /th:', ctx.message?.text);
-            return this.taskHistoryCommands.handleTaskHistoryCommand(ctx);
-        });
+    // Task history HTML command
+    this.bot.command(['th'], (ctx) => {
+      console.log('Получена команда /th:', ctx.message?.text);
+      return this.taskHistoryCommands.handleTaskHistoryCommand(ctx);
+    });
 
-        // Help command
-        this.bot.command(['help'], (ctx) => {
-            console.log('Получена команда /help');
-            return ctx.reply(this.getHelpMessage());
-        });
+    // Add new question command
+    this.bot.command(['qa'], (ctx) => {
+      console.log('Получена команда /qa:', ctx.message?.text);
+      return this.qaCommands.handleQaCommand(ctx);
+    });
 
-        // Collage command - starts interactive collage creation
-        this.bot.command(['collage', 'c'], (ctx) => {
-            console.log('Получена команда /collage /c:', ctx.message?.text);
-            return this.collageCommands.startConversation(ctx);
-        });
+    // Help command
+    this.bot.command(['help'], (ctx) => {
+      console.log('Получена команда /help');
+      return ctx.reply(this.getHelpMessage());
+    });
 
-        // Обработчик для текстовых сообщений в личных чатах и группах
-        this.bot.on(message('text'), async (ctx) => {
-            console.log('Получено текстовое сообщение:', ctx.message.text);
-            
-            if (!ctx.message.text.startsWith('/')) {
-                const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
-                await this.handleIncomingMessage(ctx.chat.id, ctx.update, isGroup);
-            }
-        });
+    // Collage command - starts interactive collage creation
+    this.bot.command(['collage', 'c'], (ctx) => {
+      console.log('Получена команда /collage /c:', ctx.message?.text);
+      return this.collageCommands.startConversation(ctx);
+    });
 
-        // Обработчик для фото в личных чатах и группах
-        this.bot.on(message('photo'), async (ctx) => {
-            console.log('Получено фото из чата/группы');
-            
-            const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
-            await this.handleIncomingPhoto(ctx, isGroup);
-        });
+    // Обработчик для текстовых сообщений в личных чатах и группах
+    this.bot.on(message('text'), async (ctx) => {
+      console.log('Получено текстовое сообщение:', ctx.message.text);
 
-        // Обработчик фото из каналов
-        this.bot.on(channelPost('photo'), async (ctx) => {
-            console.log('Получено фото из канала');
-            
-            if (!ctx.channelPost) return;
-            
-            const photoContext = {
-                ...ctx,
-                message: ctx.channelPost,
-                chat: ctx.chat,
-                updateType: 'message',
-                me: ctx.botInfo,
-                tg: ctx.telegram,
-                editedMessage: undefined,
-                state: {},
-            } as unknown as Context<Update>;
-            
-            await this.handleIncomingPhoto(photoContext, true);
-        });
+      if (!ctx.message.text.startsWith('/')) {
+        const isGroup =
+          ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+        await this.handleIncomingMessage(ctx.chat.id, ctx.update, isGroup);
+      }
+    });
 
-        // Handle collage inline buttons
-        this.bot.on('callback_query', async (ctx) => {
-            const data = (ctx.callbackQuery as any)?.data;
-            if (data === 'collage_cancel') {
-                await this.collageCommands.cancel(ctx as any);
-            } else if (data === 'collage_generate') {
-                await this.collageCommands.generate(ctx as any);
-            }
-        });
-    }
+    // Обработчик для фото в личных чатах и группах
+    this.bot.on(message('photo'), async (ctx) => {
+      console.log('Получено фото из чата/группы');
 
-    async handleIncomingMessage(chatId: number, update: TelegramUpdate, silent: boolean = false) {
-        try {
-            const messageText = this.extractMessageText(update);
-            const { date: noteDate, cleanContent } = this.dateParser.extractDateFromFirstLine(messageText);
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      await this.handleIncomingPhoto(ctx, isGroup);
+    });
 
-            // Получаем ID отправителя или создателя канала
-            let fromUserId: number | undefined = this.extractSenderId(update);
-            
-            // Если это канал и нет ID отправителя, получаем создателя канала
-            if ('channel_post' in update && !fromUserId) {
-                console.log('DEBUG: No fromUserId found, trying to get channel creator');
-                const creatorId = await this.getChannelCreatorId(chatId);
-                if (creatorId) {
-                    fromUserId = creatorId;
-                    console.log('Найден создатель канала:', fromUserId);
-                } else {
-                    console.log('DEBUG: Could not find channel creator');
-                }
-            }
+    // Обработчик фото из каналов
+    this.bot.on(channelPost('photo'), async (ctx) => {
+      console.log('Получено фото из канала');
 
-            // Сохраняем сообщение в чат/группу/канал
-            const savedNote = await this.prisma.note.create({
-                data: {
-                    content: cleanContent,
-                    rawMessage: JSON.parse(JSON.stringify(update)),
-                    chatId: chatId,
-                    noteDate: noteDate || new Date(),
-                }
-            });
+      if (!ctx.channelPost) return;
 
-            if (!silent) {
-                // Формируем и отправляем ответ бота только для личных чатов
-                const botResponse = `Сообщение сохранено${noteDate ? ` с датой ${format(noteDate, 'd MMMM yyyy', { locale: ru })}` : ''}`;
-                await this.bot.telegram.sendMessage(chatId, botResponse);
+      const photoContext = {
+        ...ctx,
+        message: ctx.channelPost,
+        chat: ctx.chat,
+        updateType: 'message',
+        me: ctx.botInfo,
+        tg: ctx.telegram,
+        editedMessage: undefined,
+        state: {},
+      } as unknown as Context<Update>;
 
-                await this.prisma.botResponse.create({
-                    data: {
-                        content: botResponse,
-                        noteId: savedNote.id,
-                        chatId: chatId,
-                    }
-                });
-            }
+      await this.handleIncomingPhoto(photoContext, true);
+    });
 
-            // Если это канал и есть ID создателя, сохраняем копию в его личный чат
-            if ('channel_post' in update && fromUserId && chatId !== fromUserId) {
-                console.log('Сохраняем копию создателю канала:', fromUserId);
-                await this.prisma.note.create({
-                    data: {
-                        content: cleanContent,
-                        rawMessage: JSON.parse(JSON.stringify(update)),
-                        chatId: fromUserId,
-                        noteDate: noteDate || new Date(),
-                    }
-                });
-            } else if ('channel_post' in update) {
-                console.log('DEBUG: Channel post detected but not copying. fromUserId:', fromUserId, 'chatId:', chatId);
-            }
-        } catch (error) {
-            console.error('Error processing message:', error);
-        }
-    }    
+    // Handle collage inline buttons
+    this.bot.on('callback_query', async (ctx) => {
+      const data = (ctx.callbackQuery as any)?.data;
+      if (data === 'collage_cancel') {
+        await this.collageCommands.cancel(ctx as any);
+      } else if (data === 'collage_generate') {
+        await this.collageCommands.generate(ctx as any);
+      }
+    });
+  }
 
-    private extractMessageText(update: TelegramUpdate): string {
-        if ('message' in update && update.message && 'text' in update.message) {
-            return update.message.text || '';
-        }
-        if ('callback_query' in update && update.callback_query.message && 'text' in update.callback_query.message) {
-            return update.callback_query.message.text || '';
-        }
-        if ('channel_post' in update && update.channel_post && 'text' in update.channel_post) {
-            return update.channel_post.text || '';
-        }
-        return '';
-    }
+  async handleIncomingMessage(
+    chatId: number,
+    update: TelegramUpdate,
+    silent: boolean = false,
+  ) {
+    try {
+      const messageText = this.extractMessageText(update);
+      const { date: noteDate, cleanContent } =
+        this.dateParser.extractDateFromFirstLine(messageText);
 
-    public async handleIncomingPhoto(ctx: Context, silent: boolean = false) {
-        try {
-            if (!ctx.message) return;
-            
-            const photos = 'photo' in ctx.message ? ctx.message.photo : null;
-            const caption = 'caption' in ctx.message ? ctx.message.caption : '';
-            
-            if (!photos || photos.length === 0 || !ctx.chat) return;
+      // Получаем ID отправителя или создателя канала
+      let fromUserId: number | undefined = this.extractSenderId(update);
 
-            // Check if interactive collage session is active
-            if (this.collageCommands.isActive(ctx.chat.id)) {
-                await this.collageCommands.addImage(ctx as any);
-                return;
-            }
-
-            // Check if this is a collage command via caption
-            if (caption && (caption.toLowerCase().includes('/collage') || caption.toLowerCase().includes('/c'))) {
-                console.log('Collage command detected in photo caption');
-                await this.collageCommands.handleCollageCommand(ctx as any);
-                return; // Exit early to prevent saving individual images
-            }
-
-            // Process all photos for database saving (original behavior)
-            const photo = photos[photos.length - 1]; // Use the highest quality photo
-            const file = await ctx.telegram.getFile(photo.file_id);
-            const photoBuffer = await this.downloadPhoto(file.file_path!);
-            const photoUrl = await this.storageService.uploadFile(
-                photoBuffer,
-                'image/jpeg',
-                ctx.chat.id
-            );
-
-            // Get image description from LLM
-            const imageDescription = await this.llmService.describeImage(photoBuffer);
-
-            const { date: noteDate, cleanContent } = this.dateParser.extractDateFromFirstLine(caption || '');
-            
-            // Получаем ID отправителя или создателя канала
-            let fromUserId: number | undefined = ctx.message.from?.id;
-            
-            // Если это канал и нет ID отправителя, получаем создателя канала
-            if (ctx.chat.type === 'channel' && !fromUserId) {
-                const creatorId = await this.getChannelCreatorId(ctx.chat.id);
-                if (creatorId) {
-                    fromUserId = creatorId;
-                    console.log('Найден создатель канала:', fromUserId);
-                } else {
-                    console.log('DEBUG: Could not find channel creator for photo');
-                }
-            }
-
-            // Сохраняем фото в чат/группу/канал
-            const savedNote = await this.prisma.note.create({
-                data: {
-                    content: cleanContent || '',
-                    rawMessage: JSON.parse(JSON.stringify(ctx.message)),
-                    chatId: ctx.chat.id,
-                    noteDate: noteDate || new Date(),
-                    images: {
-                        create: {
-                            url: photoUrl,
-                            description: imageDescription,
-                        },
-                    },
-                },
-                include: {
-                    images: true,
-                },
-            });
-
-            if (!silent) {
-                const botResponse = `Фотография сохранена${
-                    noteDate ? ` с датой ${format(noteDate, 'd MMMM yyyy', { locale: ru })}` : ''
-                }\n\nОписание: ${imageDescription}`;
-                await ctx.reply(botResponse);
-
-                await this.prisma.botResponse.create({
-                    data: {
-                        content: botResponse,
-                        noteId: savedNote.id,
-                        chatId: ctx.chat.id,
-                    }
-                });
-            }
-
-            // Если это канал и есть ID создателя, сохраняем копию фото в его личный чат
-            if (ctx.chat.type === 'channel' && fromUserId && ctx.chat.id !== fromUserId) {
-                console.log('Сохраняем копию фото создателю канала:', fromUserId);
-                await this.prisma.note.create({
-                    data: {
-                        content: cleanContent || '',
-                        rawMessage: JSON.parse(JSON.stringify(ctx.message)),
-                        chatId: fromUserId,
-                        noteDate: noteDate || new Date(),
-                        images: {
-                            create: {
-                                url: photoUrl,
-                                description: imageDescription,
-                            },
-                        },
-                    },
-                });
-            }
-        } catch (error) {
-            console.error('Error processing photo:', error);
-            if (!silent) {
-                await ctx.reply('Произошла ошибка при сохранении фотографии');
-            }
-        }
-    }
-
-    private async downloadPhoto(filePath: string): Promise<Buffer> {
-        const response = await fetch(
-            `https://api.telegram.org/file/bot${this.configService.get('TELEGRAM_BOT_TOKEN')}/${filePath}`
+      // Если это канал и нет ID отправителя, получаем создателя канала
+      if ('channel_post' in update && !fromUserId) {
+        console.log(
+          'DEBUG: No fromUserId found, trying to get channel creator',
         );
-        const arrayBuffer = await response.arrayBuffer();
-        return Buffer.from(arrayBuffer);
+        const creatorId = await this.getChannelCreatorId(chatId);
+        if (creatorId) {
+          fromUserId = creatorId;
+          console.log('Найден создатель канала:', fromUserId);
+        } else {
+          console.log('DEBUG: Could not find channel creator');
+        }
+      }
+
+      // Сохраняем сообщение в чат/группу/канал
+      const savedNote = await this.prisma.note.create({
+        data: {
+          content: cleanContent,
+          rawMessage: JSON.parse(JSON.stringify(update)),
+          chatId: chatId,
+          noteDate: noteDate || new Date(),
+        },
+      });
+
+      if (!silent) {
+        // Формируем и отправляем ответ бота только для личных чатов
+        const botResponse = `Сообщение сохранено${noteDate ? ` с датой ${format(noteDate, 'd MMMM yyyy', { locale: ru })}` : ''}`;
+        await this.bot.telegram.sendMessage(chatId, botResponse);
+
+        await this.prisma.botResponse.create({
+          data: {
+            content: botResponse,
+            noteId: savedNote.id,
+            chatId: chatId,
+          },
+        });
+      }
+
+      // Если это канал и есть ID создателя, сохраняем копию в его личный чат
+      if ('channel_post' in update && fromUserId && chatId !== fromUserId) {
+        console.log('Сохраняем копию создателю канала:', fromUserId);
+        await this.prisma.note.create({
+          data: {
+            content: cleanContent,
+            rawMessage: JSON.parse(JSON.stringify(update)),
+            chatId: fromUserId,
+            noteDate: noteDate || new Date(),
+          },
+        });
+      } else if ('channel_post' in update) {
+        console.log(
+          'DEBUG: Channel post detected but not copying. fromUserId:',
+          fromUserId,
+          'chatId:',
+          chatId,
+        );
+      }
+    } catch (error) {
+      console.error('Error processing message:', error);
+    }
+  }
+
+  private extractMessageText(update: TelegramUpdate): string {
+    if ('message' in update && update.message && 'text' in update.message) {
+      return update.message.text || '';
+    }
+    if (
+      'callback_query' in update &&
+      update.callback_query.message &&
+      'text' in update.callback_query.message
+    ) {
+      return update.callback_query.message.text || '';
+    }
+    if (
+      'channel_post' in update &&
+      update.channel_post &&
+      'text' in update.channel_post
+    ) {
+      return update.channel_post.text || '';
+    }
+    return '';
+  }
+
+  public async handleIncomingPhoto(ctx: Context, silent: boolean = false) {
+    try {
+      if (!ctx.message) return;
+
+      const photos = 'photo' in ctx.message ? ctx.message.photo : null;
+      const caption = 'caption' in ctx.message ? ctx.message.caption : '';
+
+      if (!photos || photos.length === 0 || !ctx.chat) return;
+
+      // Check if interactive collage session is active
+      if (this.collageCommands.isActive(ctx.chat.id)) {
+        await this.collageCommands.addImage(ctx as any);
+        return;
+      }
+
+      // Check if this is a collage command via caption
+      if (
+        caption &&
+        (caption.toLowerCase().includes('/collage') ||
+          caption.toLowerCase().includes('/c'))
+      ) {
+        console.log('Collage command detected in photo caption');
+        await this.collageCommands.handleCollageCommand(ctx as any);
+        return; // Exit early to prevent saving individual images
+      }
+
+      // Process all photos for database saving (original behavior)
+      const photo = photos[photos.length - 1]; // Use the highest quality photo
+      const file = await ctx.telegram.getFile(photo.file_id);
+      const photoBuffer = await this.downloadPhoto(file.file_path!);
+      const photoUrl = await this.storageService.uploadFile(
+        photoBuffer,
+        'image/jpeg',
+        ctx.chat.id,
+      );
+
+      // Get image description from LLM
+      const imageDescription = await this.llmService.describeImage(photoBuffer);
+
+      const { date: noteDate, cleanContent } =
+        this.dateParser.extractDateFromFirstLine(caption || '');
+
+      // Получаем ID отправителя или создателя канала
+      let fromUserId: number | undefined = ctx.message.from?.id;
+
+      // Если это канал и нет ID отправителя, получаем создателя канала
+      if (ctx.chat.type === 'channel' && !fromUserId) {
+        const creatorId = await this.getChannelCreatorId(ctx.chat.id);
+        if (creatorId) {
+          fromUserId = creatorId;
+          console.log('Найден создатель канала:', fromUserId);
+        } else {
+          console.log('DEBUG: Could not find channel creator for photo');
+        }
+      }
+
+      // Сохраняем фото в чат/группу/канал
+      const savedNote = await this.prisma.note.create({
+        data: {
+          content: cleanContent || '',
+          rawMessage: JSON.parse(JSON.stringify(ctx.message)),
+          chatId: ctx.chat.id,
+          noteDate: noteDate || new Date(),
+          images: {
+            create: {
+              url: photoUrl,
+              description: imageDescription,
+            },
+          },
+        },
+        include: {
+          images: true,
+        },
+      });
+
+      if (!silent) {
+        const botResponse = `Фотография сохранена${
+          noteDate
+            ? ` с датой ${format(noteDate, 'd MMMM yyyy', { locale: ru })}`
+            : ''
+        }\n\nОписание: ${imageDescription}`;
+        await ctx.reply(botResponse);
+
+        await this.prisma.botResponse.create({
+          data: {
+            content: botResponse,
+            noteId: savedNote.id,
+            chatId: ctx.chat.id,
+          },
+        });
+      }
+
+      // Если это канал и есть ID создателя, сохраняем копию фото в его личный чат
+      if (
+        ctx.chat.type === 'channel' &&
+        fromUserId &&
+        ctx.chat.id !== fromUserId
+      ) {
+        console.log('Сохраняем копию фото создателю канала:', fromUserId);
+        await this.prisma.note.create({
+          data: {
+            content: cleanContent || '',
+            rawMessage: JSON.parse(JSON.stringify(ctx.message)),
+            chatId: fromUserId,
+            noteDate: noteDate || new Date(),
+            images: {
+              create: {
+                url: photoUrl,
+                description: imageDescription,
+              },
+            },
+          },
+        });
+      }
+    } catch (error) {
+      console.error('Error processing photo:', error);
+      if (!silent) {
+        await ctx.reply('Произошла ошибка при сохранении фотографии');
+      }
+    }
+  }
+
+  private async downloadPhoto(filePath: string): Promise<Buffer> {
+    const response = await fetch(
+      `https://api.telegram.org/file/bot${this.configService.get('TELEGRAM_BOT_TOKEN')}/${filePath}`,
+    );
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+
+  private extractSenderId(update: TelegramUpdate): number | undefined {
+    if ('message' in update && update.message?.from) {
+      return update.message.from.id;
+    }
+    if ('callback_query' in update && update.callback_query?.from) {
+      return update.callback_query.from.id;
+    }
+    if ('channel_post' in update && update.channel_post?.from) {
+      console.log(
+        'DEBUG: Found from field in channel_post:',
+        update.channel_post.from,
+      );
+      return update.channel_post.from.id;
+    }
+    if ('channel_post' in update) {
+      console.log(
+        'DEBUG: Channel post has no from field:',
+        update.channel_post,
+      );
+    }
+    return undefined;
+  }
+
+  private async getChannelCreatorId(
+    chatId: number,
+  ): Promise<number | undefined> {
+    // Сначала проверяем маппинг
+    if (this.channelCreatorMapping.has(chatId)) {
+      const creatorId = this.channelCreatorMapping.get(chatId);
+      console.log('DEBUG: Found creator in mapping:', creatorId);
+      return creatorId;
     }
 
-    private extractSenderId(update: TelegramUpdate): number | undefined {
-        if ('message' in update && update.message?.from) {
-            return update.message.from.id;
-        }
-        if ('callback_query' in update && update.callback_query?.from) {
-            return update.callback_query.from.id;
-        }
-        if ('channel_post' in update && update.channel_post?.from) {
-            console.log('DEBUG: Found from field in channel_post:', update.channel_post.from);
-            return update.channel_post.from.id;
-        }
-        if ('channel_post' in update) {
-            console.log('DEBUG: Channel post has no from field:', update.channel_post);
-        }
-        return undefined;
+    // Если нет в маппинге, пытаемся получить через API
+    try {
+      const admins = await this.bot.telegram.getChatAdministrators(chatId);
+      const creator = admins.find((admin) => admin.status === 'creator');
+      if (creator) {
+        const creatorId = creator.user.id;
+        // Сохраняем в маппинг для будущего использования
+        this.channelCreatorMapping.set(chatId, creatorId);
+        console.log(
+          'DEBUG: Found creator via API and saved to mapping:',
+          creatorId,
+        );
+        return creatorId;
+      }
+    } catch (error) {
+      console.error(
+        'Ошибка при получении информации о создателе канала:',
+        error,
+      );
     }
 
-    private async getChannelCreatorId(chatId: number): Promise<number | undefined> {
-        // Сначала проверяем маппинг
-        if (this.channelCreatorMapping.has(chatId)) {
-            const creatorId = this.channelCreatorMapping.get(chatId);
-            console.log('DEBUG: Found creator in mapping:', creatorId);
-            return creatorId;
-        }
+    return undefined;
+  }
 
-        // Если нет в маппинге, пытаемся получить через API
-        try {
-            const admins = await this.bot.telegram.getChatAdministrators(chatId);
-            const creator = admins.find(admin => admin.status === 'creator');
-            if (creator) {
-                const creatorId = creator.user.id;
-                // Сохраняем в маппинг для будущего использования
-                this.channelCreatorMapping.set(chatId, creatorId);
-                console.log('DEBUG: Found creator via API and saved to mapping:', creatorId);
-                return creatorId;
-            }
-        } catch (error) {
-            console.error('Ошибка при получении информации о создателе канала:', error);
-        }
-        
-        return undefined;
-    }
+  private getHelpMessage(): string {
+    const commands = [
+      { name: '/d or /dairy', description: 'Dairy Notes' },
+      { name: '/history', description: 'Chat History' },
+      { name: '/s', description: 'Serbian Translation' },
+      { name: '/t or /task', description: 'Create Todo item' },
+      { name: '/tl', description: 'List Todo items' },
+      { name: '/th', description: 'Tasks HTML export' },
+      { name: '/qa', description: 'Add question' },
+      { name: '/c or /collage', description: 'Create image collage' },
+      { name: '/help', description: 'Show this help message' },
+    ];
+    commands.sort((a, b) => a.name.localeCompare(b.name));
+    return commands.map((c) => `${c.name} - ${c.description}`).join('\n');
+  }
 
-    private getHelpMessage(): string {
-        const commands = [
-            { name: '/d or /dairy', description: 'Dairy Notes' },
-            { name: '/history', description: 'Chat History' },
-            { name: '/s', description: 'Serbian Translation' },
-            { name: '/t or /task', description: 'Create Todo item' },
-            { name: '/tl', description: 'List Todo items' },
-            { name: '/th', description: 'Tasks HTML export' },
-            { name: '/c or /collage', description: 'Create image collage' },
-            { name: '/help', description: 'Show this help message' },
-        ];
-        commands.sort((a, b) => a.name.localeCompare(b.name));
-        return commands.map(c => `${c.name} - ${c.description}`).join('\n');
-    }
+  // Метод для добавления маппинга канала к создателю
+  addChannelCreatorMapping(channelId: number, creatorId: number) {
+    this.channelCreatorMapping.set(channelId, creatorId);
+    console.log(`Added channel mapping: ${channelId} -> ${creatorId}`);
+  }
 
-    // Метод для добавления маппинга канала к создателю
-    addChannelCreatorMapping(channelId: number, creatorId: number) {
-        this.channelCreatorMapping.set(channelId, creatorId);
-        console.log(`Added channel mapping: ${channelId} -> ${creatorId}`);
-    }
-
-    // Добавляем метод для обработки webhook-обновлений
-    async handleWebhook(update: Update) {
-        return this.bot.handleUpdate(update);
-    }
+  // Добавляем метод для обработки webhook-обновлений
+  async handleWebhook(update: Update) {
+    return this.bot.handleUpdate(update);
+  }
 }


### PR DESCRIPTION
## Summary
- implement new QaCommandsService
- register `/qa` command in TelegramBotService
- expose QaCommandsService via TelegramBotModule
- update help message and README docs
- adjust unit tests for new service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bce63bc28832b9f7ae427dfd799fe