### PR TITLE
Implement /ql command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ Example:
 /qa How many apples do you have?
 ```
 
+### `/ql`
+
+Lists all questions for the current chat.
+
+Example:
+
+```
+/ql
+```
+
 ### `/help`
 
 Shows a list of all available commands.

--- a/src/telegram-bot/qa-commands.service.spec.ts
+++ b/src/telegram-bot/qa-commands.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QaCommandsService } from './qa-commands.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { Context } from 'telegraf';
+
+describe('QaCommandsService', () => {
+  let service: QaCommandsService;
+  const mockPrisma = {
+    question: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QaCommandsService, { provide: PrismaService, useValue: mockPrisma }],
+    }).compile();
+
+    service = module.get<QaCommandsService>(QaCommandsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should reply when no questions', async () => {
+    const ctx: any = { chat: { id: 123 }, reply: jest.fn() };
+    mockPrisma.question.findMany.mockResolvedValue([]);
+    await service.handleQlCommand(ctx as unknown as Context);
+    expect(ctx.reply).toHaveBeenCalledWith('No questions found in this chat');
+  });
+
+  it('should list questions', async () => {
+    const ctx: any = { chat: { id: 123 }, reply: jest.fn() };
+    mockPrisma.question.findMany.mockResolvedValue([
+      { questionText: 'Q1', createdAt: new Date() },
+      { questionText: 'Q2', createdAt: new Date() },
+    ]);
+    await service.handleQlCommand(ctx as unknown as Context);
+    expect(ctx.reply).toHaveBeenCalledWith('Q1\nQ2');
+  });
+});

--- a/src/telegram-bot/qa-commands.service.ts
+++ b/src/telegram-bot/qa-commands.service.ts
@@ -34,6 +34,24 @@ export class QaCommandsService {
     }
   }
 
+  async handleQlCommand(ctx: Context) {
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+
+    const questions = await this.prisma.question.findMany({
+      where: { chatId },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    if (questions.length === 0) {
+      await ctx.reply('No questions found in this chat');
+      return;
+    }
+
+    const lines = questions.map((q) => q.questionText);
+    await ctx.reply(lines.join('\n'));
+  }
+
   private getCommandText(ctx: Context): string | undefined {
     if ('message' in ctx && ctx.message && 'text' in ctx.message) {
       return ctx.message.text;

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -152,6 +152,7 @@ describe('TelegramBotService', () => {
           provide: QaCommandsService,
           useValue: {
             handleQaCommand: jest.fn(),
+            handleQlCommand: jest.fn(),
           },
         },
       ],
@@ -191,6 +192,7 @@ describe('TelegramBotService', () => {
       '/help - Show this help message',
       '/history - Chat History',
       '/qa - Add question',
+      '/ql - List questions',
       '/s - Serbian Translation',
       '/t or /task - Create Todo item',
       '/th - Tasks HTML export',

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -151,6 +151,12 @@ export class TelegramBotService {
       return this.qaCommands.handleQaCommand(ctx);
     });
 
+    // List questions command
+    this.bot.command(['ql'], (ctx) => {
+      console.log('Получена команда /ql:', ctx.message?.text);
+      return this.qaCommands.handleQlCommand(ctx);
+    });
+
     // Help command
     this.bot.command(['help'], (ctx) => {
       console.log('Получена команда /help');
@@ -506,6 +512,7 @@ export class TelegramBotService {
       { name: '/tl', description: 'List Todo items' },
       { name: '/th', description: 'Tasks HTML export' },
       { name: '/qa', description: 'Add question' },
+      { name: '/ql', description: 'List questions' },
       { name: '/c or /collage', description: 'Create image collage' },
       { name: '/help', description: 'Show this help message' },
     ];


### PR DESCRIPTION
## Summary
- implement `/ql` command in QA service
- expose `/ql` through the Telegram bot
- document the new command
- update help message and tests
- add unit test coverage for QA listing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687be66d6cb4832b8c75afd78e57431f