### PR TITLE
Enable natural language dates for task due dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Creates a new todo item.
 - `!project` — assign projects (multiword names are allowed).
 - `(A)` — set priority with a letter in parentheses.
 - `:<date>` or `:<date> HH:MM` — optional due date. `<date>` accepts the same formats as in the note examples above.
+- You can also use words like `tomorrow` or day names (`sunday`, `понедельник`, etc.) for the due date.
 
 To update an existing task, start the command with its key:
 `/t T-20250710-03 ...`. New tags and contexts are appended while

--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -41,6 +41,31 @@ describe('TaskCommandsService', () => {
       expect(result?.getMonth()).toBe(0);
       expect(result?.getDate()).toBe(2);
     });
+
+    it('should parse "tomorrow" with time', () => {
+      const result = (service as any).parseDueDate('tomorrow 10:15');
+      const expected = new Date();
+      expected.setDate(expected.getDate() + 1);
+      expected.setHours(10, 15, 0, 0);
+      expect(result?.getFullYear()).toBe(expected.getFullYear());
+      expect(result?.getMonth()).toBe(expected.getMonth());
+      expect(result?.getDate()).toBe(expected.getDate());
+      expect(result?.getHours()).toBe(10);
+      expect(result?.getMinutes()).toBe(15);
+    });
+
+    it('should parse russian day of week', () => {
+      const result = (service as any).parseDueDate('понедельник');
+      expect(result).toBeInstanceOf(Date);
+      const today = new Date();
+      const targetDay = 1; // Monday
+      let diff = (targetDay - today.getDay() + 7) % 7;
+      if (diff === 0) diff = 7;
+      const expected = new Date();
+      expected.setDate(expected.getDate() + diff);
+      expect(result?.getDate()).toBe(expected.getDate());
+      expect(result?.getMonth()).toBe(expected.getMonth());
+    });
   });
 
   describe('parseTask', () => {


### PR DESCRIPTION
## Summary
- allow natural language dates like `tomorrow` or weekday names when parsing task due dates
- document new due-date formats in the README
- add tests covering `tomorrow` and Russian weekday parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0af52480832bae6870db1a846d71