### PR TITLE
Sort /tl by due date

### DIFF
--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -171,4 +171,28 @@ describe('TaskCommandsService', () => {
       expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining('Format:'));
     });
   });
+
+  describe('handleListCommand', () => {
+    it('should sort tasks by due date', async () => {
+      const mockPrisma = {
+        $queryRawUnsafe: jest.fn().mockResolvedValue([]),
+        todo: { count: jest.fn() },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [TaskCommandsService, DateParserService, { provide: PrismaService, useValue: mockPrisma }],
+      }).compile();
+
+      const svc = module.get<TaskCommandsService>(TaskCommandsService);
+      const ctx: any = {
+        message: { text: '/tl' },
+        chat: { id: 123456 },
+        reply: jest.fn(),
+      };
+      await svc.handleListCommand(ctx);
+      expect(mockPrisma.$queryRawUnsafe).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY "dueDate" IS NULL, "dueDate" ASC')
+      );
+    });
+  });
 });

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -283,7 +283,7 @@ export class TaskCommandsService {
             query += ` AND projects @> '${JSON.stringify(projects)}'::jsonb`;
         }
 
-        query += ` ORDER BY "createdAt" DESC, key ASC`;
+        query += ` ORDER BY "dueDate" IS NULL, "dueDate" ASC, "createdAt" DESC, key ASC`;
 
         // Use CTE to get latest record for each key, then apply filters
         const latestTasks = await this.prisma.$queryRawUnsafe<Array<{


### PR DESCRIPTION
## Summary
- order task list by due date
- add regression test for handleListCommand query

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0bf7b358832b91144a1159e54f23