### PR TITLE
Fix lint issues

### DIFF
--- a/src/scripts/update-image-descriptions.ts
+++ b/src/scripts/update-image-descriptions.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '../generated/prisma-client';
+import { PrismaClient, Prisma } from '../generated/prisma-client';
 import { LlmService } from '../services/llm.service';
 import { StorageService } from '../services/storage.service';
 import { ConfigService } from '@nestjs/config';
@@ -47,7 +47,7 @@ async function updateImageDescriptions() {
     }
 
     // Get images without descriptions, ordered by creation date (newest first)
-    const imagesQuery: any = {
+    const imagesQuery: Prisma.ImageFindManyArgs = {
       where: {
         OR: [{ description: null }, { description: '' }],
       },
@@ -61,7 +61,7 @@ async function updateImageDescriptions() {
 
     // Apply limit if specified
     if (limit) {
-      imagesQuery['take'] = limit;
+      imagesQuery.take = limit;
     }
 
     const imagesWithoutDescriptions = await prisma.image.findMany(imagesQuery);

--- a/src/services/llm.service.ts
+++ b/src/services/llm.service.ts
@@ -49,14 +49,14 @@ export class LlmService {
       );
 
       if (!response.ok) {
-        const errorData = await response.json();
+        const errorData: unknown = await response.json();
         console.error('OpenAI API error:', errorData);
         throw new Error(
           `OpenAI API error: ${response.status} ${response.statusText}`,
         );
       }
 
-      const data = (await response.json()) as {
+      const data = (await response.json()) as unknown as {
         choices: Array<{
           message: {
             content: string;

--- a/src/telegram-bot/collage-commands.service.spec.ts
+++ b/src/telegram-bot/collage-commands.service.spec.ts
@@ -5,18 +5,22 @@ import { StorageService } from '../services/storage.service';
 import { Context } from 'telegraf';
 
 jest.mock('sharp', () => {
-  const sharpMock = jest.fn(() => ({
-    resize: jest.fn().mockReturnThis(),
-    jpeg: jest.fn().mockReturnThis(),
-    toBuffer: jest.fn().mockResolvedValue(Buffer.from('valid-image')),
-    composite: jest.fn().mockReturnThis(),
-    metadata: jest.fn().mockResolvedValue({ width: 800, height: 600 }),
-  }));
-  (sharpMock as any).create = jest.fn(() => ({
-    composite: jest.fn().mockReturnThis(),
-    jpeg: jest.fn().mockReturnThis(),
-    toBuffer: jest.fn().mockResolvedValue(Buffer.from('valid-image')),
-  })) as any;
+  const sharpMock: jest.Mock & { create: jest.Mock } = Object.assign(
+    jest.fn(() => ({
+      resize: jest.fn().mockReturnThis(),
+      jpeg: jest.fn().mockReturnThis(),
+      toBuffer: jest.fn().mockResolvedValue(Buffer.from('valid-image')),
+      composite: jest.fn().mockReturnThis(),
+      metadata: jest.fn().mockResolvedValue({ width: 800, height: 600 }),
+    })),
+    {
+      create: jest.fn(() => ({
+        composite: jest.fn().mockReturnThis(),
+        jpeg: jest.fn().mockReturnThis(),
+        toBuffer: jest.fn().mockResolvedValue(Buffer.from('valid-image')),
+      })),
+    },
+  );
   return sharpMock;
 });
 

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -1,8 +1,13 @@
 import { Injectable } from '@nestjs/common';
-import { Update, Message } from 'telegraf/typings/core/types/typegram';
+import {
+  Update,
+  Message,
+  CallbackQuery,
+} from 'telegraf/typings/core/types/typegram';
 import { Telegraf, Context } from 'telegraf';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '../generated/prisma-client';
 import { DateParserService } from '../services/date-parser.service';
 import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
@@ -211,7 +216,8 @@ export class TelegramBotService {
 
     // Handle collage inline buttons
     this.bot.on('callback_query', async (ctx) => {
-      const data = (ctx.callbackQuery as any)?.data;
+      const data = (ctx.callbackQuery as CallbackQuery.DataQuery | undefined)
+        ?.data;
       if (data === 'collage_cancel') {
         await this.collageCommands.cancel(ctx);
       } else if (data === 'collage_generate') {
@@ -251,7 +257,9 @@ export class TelegramBotService {
       const savedNote = await this.prisma.note.create({
         data: {
           content: cleanContent,
-          rawMessage: JSON.parse(JSON.stringify(update)),
+          rawMessage: JSON.parse(
+            JSON.stringify(update),
+          ) as unknown as Prisma.InputJsonValue,
           chatId: chatId,
           noteDate: noteDate || new Date(),
         },
@@ -277,7 +285,9 @@ export class TelegramBotService {
         await this.prisma.note.create({
           data: {
             content: cleanContent,
-            rawMessage: JSON.parse(JSON.stringify(update)),
+            rawMessage: JSON.parse(
+              JSON.stringify(update),
+            ) as unknown as Prisma.InputJsonValue,
             chatId: fromUserId,
             noteDate: noteDate || new Date(),
           },
@@ -376,7 +386,9 @@ export class TelegramBotService {
       const savedNote = await this.prisma.note.create({
         data: {
           content: cleanContent || '',
-          rawMessage: JSON.parse(JSON.stringify(ctx.message)),
+          rawMessage: JSON.parse(
+            JSON.stringify(ctx.message),
+          ) as unknown as Prisma.InputJsonValue,
           chatId: ctx.chat.id,
           noteDate: noteDate || new Date(),
           images: {
@@ -418,7 +430,9 @@ export class TelegramBotService {
         await this.prisma.note.create({
           data: {
             content: cleanContent || '',
-            rawMessage: JSON.parse(JSON.stringify(ctx.message)),
+            rawMessage: JSON.parse(
+              JSON.stringify(ctx.message),
+            ) as unknown as Prisma.InputJsonValue,
             chatId: fromUserId,
             noteDate: noteDate || new Date(),
             images: {


### PR DESCRIPTION
## Summary
- adjust Sharp mock typing
- type Prisma queries and JSON values
- tune LLM service data handling
- cleanup callback query handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e5fc0cb18832baed9d9934bcc6630