### PR TITLE
Fix due date time parsing

### DIFF
--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -151,6 +151,23 @@ describe('TaskCommandsService', () => {
       );
       expect(timeDiff).toBeLessThan(60000); // less than 1 minute
     });
+
+    it('should parse due date with single digit hour', () => {
+      const svc = service as unknown as {
+        parseTask(text: string): {
+          content: string;
+          dueDate?: Date;
+        };
+      };
+      const result = svc.parseTask(':2025.07.24 8:30') as {
+        content: string;
+        dueDate?: Date;
+      };
+      expect(result.content).toBe('');
+      expect(result.dueDate).toBeInstanceOf(Date);
+      expect(result.dueDate?.getHours()).toBe(8);
+      expect(result.dueDate?.getMinutes()).toBe(30);
+    });
   });
 
   describe('parseFilters', () => {

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -169,7 +169,7 @@ export class TaskCommandsService {
       }
       if (token.startsWith(':')) {
         let dateStr = token.slice(1);
-        if (i + 1 < tokens.length && /\d{2}:\d{2}/.test(tokens[i + 1])) {
+        if (i + 1 < tokens.length && /^\d{1,2}:\d{2}$/.test(tokens[i + 1])) {
           dateStr += ` ${tokens[i + 1]}`;
           i++;
         }


### PR DESCRIPTION
## Summary
- support single-digit hour when parsing due date tokens
- test for single-digit hour parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6d567234832ba1fb84595271c931