### PR TITLE
Add interactive /qa command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,10 @@ History lines show only what changed instead of repeating the full task text.
 
 ### `/qa`
 
-Adds a new question for the current chat.
+Starts an interactive flow to add a question.
 
-Example:
-
-```
-/qa How many apples do you have?
-```
+1. Send `/qa` and provide the question text when prompted.
+2. Choose its type (string, number or boolean) using the inline buttons.
 
 ### `/ql`
 

--- a/src/telegram-bot/qa-commands.service.ts
+++ b/src/telegram-bot/qa-commands.service.ts
@@ -1,36 +1,98 @@
 import { Injectable } from '@nestjs/common';
 import { Context } from 'telegraf';
+import {
+  CallbackQuery,
+  InlineKeyboardMarkup,
+} from 'telegraf/typings/core/types/typegram';
 import { PrismaService } from '../prisma/prisma.service';
+
+interface QaSession {
+  step: 'await_question' | 'await_type';
+  questionText?: string;
+}
 
 @Injectable()
 export class QaCommandsService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private readonly sessions: Map<number, QaSession> = new Map();
+
+  isActive(chatId: number): boolean {
+    return this.sessions.has(chatId);
+  }
 
   async handleQaCommand(ctx: Context) {
     const chatId = ctx.chat?.id;
     if (!chatId) return;
 
     const messageText = this.getCommandText(ctx);
-    if (!messageText) return;
-
     const questionText = messageText.replace(/^\/qa\s*/, '').trim();
-    if (!questionText) {
-      await ctx.reply('Please provide question text after the command');
-      return;
+
+    if (questionText) {
+      this.sessions.set(chatId, { step: 'await_type', questionText });
+      await ctx.reply('Choose question type', {
+        reply_markup: { inline_keyboard: this.getTypeKeyboard() },
+      });
+    } else {
+      this.sessions.set(chatId, { step: 'await_question' });
+      await ctx.reply('Please send the question text');
     }
+  }
+
+  async handleText(ctx: Context) {
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    const session = this.sessions.get(chatId);
+    if (!session) return;
+
+    if (session.step === 'await_question' && ctx.message && 'text' in ctx.message) {
+      session.questionText = ctx.message.text;
+      session.step = 'await_type';
+      this.sessions.set(chatId, session);
+      await ctx.reply('Choose question type', {
+        reply_markup: { inline_keyboard: this.getTypeKeyboard() },
+      });
+    }
+  }
+
+  async handleTypeSelection(ctx: Context) {
+    const chatId = ctx.chat?.id || ctx.from?.id;
+    if (!chatId) return;
+    const session = this.sessions.get(chatId);
+    if (!session || session.step !== 'await_type' || !session.questionText) return;
+
+    const data = (ctx.callbackQuery as CallbackQuery.DataQuery | undefined)?.data;
+    const typeMap: Record<string, string> = {
+      qa_type_string: 'text',
+      qa_type_number: 'number',
+      qa_type_boolean: 'binary',
+    };
+    const type = data ? typeMap[data] : undefined;
+    if (!type) return;
+
+    await ctx.answerCbQuery();
+    await (
+      ctx as Context & {
+        editMessageReplyMarkup: (
+          markup: InlineKeyboardMarkup | undefined,
+        ) => Promise<void>;
+      }
+    ).editMessageReplyMarkup(undefined);
 
     try {
       await this.prisma.question.create({
         data: {
           chatId,
-          questionText,
-          type: 'text',
+          questionText: session.questionText,
+          type,
         },
       });
       await ctx.reply('Question added');
     } catch (error) {
       console.error('Error saving question:', error);
       await ctx.reply('Error saving question');
+    } finally {
+      this.sessions.delete(chatId);
     }
   }
 
@@ -52,13 +114,23 @@ export class QaCommandsService {
     await ctx.reply(lines.join('\n'));
   }
 
-  private getCommandText(ctx: Context): string | undefined {
+  private getCommandText(ctx: Context): string {
     if ('message' in ctx && ctx.message && 'text' in ctx.message) {
       return ctx.message.text;
     }
     if ('channelPost' in ctx && ctx.channelPost && 'text' in ctx.channelPost) {
       return ctx.channelPost.text;
     }
-    return undefined;
+    return '';
+  }
+
+  private getTypeKeyboard() {
+    return [
+      [
+        { text: 'String', callback_data: 'qa_type_string' },
+        { text: 'Number', callback_data: 'qa_type_number' },
+        { text: 'Boolean', callback_data: 'qa_type_boolean' },
+      ],
+    ];
   }
 }

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -178,6 +178,11 @@ export class TelegramBotService {
     this.bot.on(message('text'), async (ctx) => {
       console.log('Получено текстовое сообщение:', ctx.message.text);
 
+      if (this.qaCommands.isActive(ctx.chat.id)) {
+        await this.qaCommands.handleText(ctx);
+        return;
+      }
+
       if (!ctx.message.text.startsWith('/')) {
         const isGroup =
           ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
@@ -214,7 +219,7 @@ export class TelegramBotService {
       await this.handleIncomingPhoto(photoContext, true);
     });
 
-    // Handle collage inline buttons
+    // Handle inline buttons
     this.bot.on('callback_query', async (ctx) => {
       const data = (ctx.callbackQuery as CallbackQuery.DataQuery | undefined)
         ?.data;
@@ -222,6 +227,12 @@ export class TelegramBotService {
         await this.collageCommands.cancel(ctx);
       } else if (data === 'collage_generate') {
         await this.collageCommands.generate(ctx);
+      } else if (
+        data === 'qa_type_string' ||
+        data === 'qa_type_number' ||
+        data === 'qa_type_boolean'
+      ) {
+        await this.qaCommands.handleTypeSelection(ctx);
       }
     });
   }


### PR DESCRIPTION
## Summary
- convert `/qa` into a multi-step flow
- track pending question sessions
- support choosing a question type via buttons
- update message handler and callback handling
- document interactive flow in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6d67ebbc832b9f1171ef86168e0b