### PR TITLE
Include task title in /th history

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Tasks are organized into three categories:
 - **Finished**: Completed or canceled tasks sorted by creation date
 
 The snoozed until date is displayed for snoozed tasks.
-History lines show only what changed instead of repeating the full task text.
+History lines show only what changed instead of repeating the full task text,
+and the first history entry now includes the task title.
 
 ### `/qa`
 

--- a/src/telegram-bot/task-history-commands.service.ts
+++ b/src/telegram-bot/task-history-commands.service.ts
@@ -150,7 +150,7 @@ export class TaskHistoryCommandsService {
         const h = g.history[i];
         html += `<li>${format(new Date(h.createdAt), 'yyyy-MM-dd HH:mm')} - `;
         if (i === 0) {
-          html += 'created';
+          html += `created: ${this.escapeHtml(h.content)}`;
         } else {
           const prev = g.history[i - 1];
           const changes = this.describeChanges(prev, h);


### PR DESCRIPTION
## Summary
- improve `/th` HTML export formatting by including the task title in the first history entry
- document the change in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6d9ebb3c832b96e75f54690778d6