### PR TITLE
Add /qq command for questions with answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ Example:
 /ql
 ```
 
+### `/qq`
+
+Shows the list of questions with their answers for the specified date (or today if no date is given).
+
+Example:
+
+```
+/qq 02.01.2025
+```
+
 ### `/help`
 
 Shows a list of all available commands.

--- a/src/telegram-bot/qa-commands.service.spec.ts
+++ b/src/telegram-bot/qa-commands.service.spec.ts
@@ -158,4 +158,22 @@ describe('QaCommandsService', () => {
       data: { textAnswer: 'yes' },
     });
   });
+
+  it('should list questions with answers for a date', async () => {
+    const mockReply = jest.fn();
+    const ctx = { chat: { id: 4 }, reply: mockReply } as unknown as Context;
+    mockPrisma.question.findMany.mockResolvedValue([
+      {
+        id: 30,
+        questionText: 'How are you?',
+        type: 'text',
+        createdAt: new Date(),
+        Answer: [
+          { textAnswer: 'fine', numberAnswer: null, answerDate: new Date() },
+        ],
+      },
+    ]);
+    await service.handleQqCommand(ctx);
+    expect(mockReply).toHaveBeenCalledWith('How are you?: fine');
+  });
 });

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -198,6 +198,7 @@ describe('TelegramBotService', () => {
       '/q - Answer questions',
       '/qa - Add question',
       '/ql - List questions',
+      '/qq - Questions and answers for a date',
       '/s - Serbian Translation',
       '/t or /task - Create Todo item',
       '/th - Tasks HTML export',

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -168,6 +168,12 @@ export class TelegramBotService {
       return this.qaCommands.handleQCommand(ctx);
     });
 
+    // Questions report command
+    this.bot.command(['qq'], (ctx) => {
+      console.log('Получена команда /qq:', ctx.message?.text);
+      return this.qaCommands.handleQqCommand(ctx);
+    });
+
     // Help command
     this.bot.command(['help'], (ctx) => {
       console.log('Получена команда /help');
@@ -546,6 +552,7 @@ export class TelegramBotService {
       { name: '/th', description: 'Tasks HTML export' },
       { name: '/qa', description: 'Add question' },
       { name: '/ql', description: 'List questions' },
+      { name: '/qq', description: 'Questions and answers for a date' },
       { name: '/q', description: 'Answer questions' },
       { name: '/c or /collage', description: 'Create image collage' },
       { name: '/help', description: 'Show this help message' },


### PR DESCRIPTION
## Summary
- implement `/qq` command to list questions with answers for a chosen date
- register new command and update help text
- document `/qq` usage in README
- test question report flow and update help message test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f8c429c9c832bb76b565c31a09a4a