### PR TITLE
Implement /qh command

### DIFF
--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -154,6 +154,7 @@ describe('TelegramBotService', () => {
           useValue: {
             handleQaCommand: jest.fn(),
             handleQlCommand: jest.fn(),
+            handleQhCommand: jest.fn(),
           },
         },
       ],
@@ -197,6 +198,7 @@ describe('TelegramBotService', () => {
       '/history - Chat History',
       '/q - Answer questions',
       '/qa - Add question',
+      '/qh - Questions history HTML export',
       '/ql - List questions',
       '/qq - Questions and answers for a date',
       '/s - Serbian Translation',

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -174,6 +174,12 @@ export class TelegramBotService {
       return this.qaCommands.handleQqCommand(ctx);
     });
 
+    // Questions history command
+    this.bot.command(['qh'], (ctx) => {
+      console.log('Получена команда /qh:', ctx.message?.text);
+      return this.qaCommands.handleQhCommand(ctx);
+    });
+
     // Help command
     this.bot.command(['help'], (ctx) => {
       console.log('Получена команда /help');
@@ -553,6 +559,7 @@ export class TelegramBotService {
       { name: '/qa', description: 'Add question' },
       { name: '/ql', description: 'List questions' },
       { name: '/qq', description: 'Questions and answers for a date' },
+      { name: '/qh', description: 'Questions history HTML export' },
       { name: '/q', description: 'Answer questions' },
       { name: '/c or /collage', description: 'Create image collage' },
       { name: '/help', description: 'Show this help message' },


### PR DESCRIPTION
## Summary
- add `/qh` command to publish question history HTML
- upload last 30 days of answers to DO Space
- support the new command in Telegram service and help
- test new functionality

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687fa3fba1d0832b84a5ab7043526531