### PR TITLE
Add special collage layout with background images

### DIFF
--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -245,6 +245,8 @@ export class TelegramBotService {
         await this.collageCommands.cancel(ctx);
       } else if (data === 'collage_generate') {
         await this.collageCommands.generate(ctx);
+      } else if (data === 'collage_generate_special') {
+        await this.collageCommands.generateSpecial(ctx);
       } else if (
         data === 'qa_type_string' ||
         data === 'qa_type_number' ||


### PR DESCRIPTION
## Summary
- add optional button when 5 images are uploaded for `/c`
- handle new `collage_generate_special` callback
- implement `generateSpecial` and `createSpecialCollage` for new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880aec3bc30832bb8fba09676cef1e9