### PR TITLE
Add circular special collage option

### DIFF
--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -247,6 +247,8 @@ export class TelegramBotService {
         await this.collageCommands.generate(ctx);
       } else if (data === 'collage_generate_special') {
         await this.collageCommands.generateSpecial(ctx);
+      } else if (data === 'collage_generate_special2') {
+        await this.collageCommands.generateSpecial2(ctx);
       } else if (
         data === 'qa_type_string' ||
         data === 'qa_type_number' ||


### PR DESCRIPTION
## Summary
- add a second special collage button
- support generating special collage with a circular main image
- handle new callback in Telegram bot service

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880cca2c770832b9c0ba2bf4a1ab575