### PR TITLE
Add white border on circle collage

### DIFF
--- a/src/telegram-bot/collage-commands.service.ts
+++ b/src/telegram-bot/collage-commands.service.ts
@@ -573,27 +573,35 @@ export class CollageCommandsService {
       }
 
       const diameter = Math.floor(Math.min(width, height) * 0.8);
+      const border = 5;
+
       const circleSvg = Buffer.from(
         `<svg width="${diameter}" height="${diameter}"><circle cx="${
           diameter / 2
         }" cy="${diameter / 2}" r="${diameter / 2}" fill="white" /></svg>`,
       );
 
-      const mainCircle = await sharp(imageBuffers[0])
+      const baseCircle = await sharp(imageBuffers[0])
         .resize(diameter, diameter, { fit: 'cover', position: 'centre' })
         .composite([{ input: circleSvg, blend: 'dest-in' }])
-        .extend({
-          top: 5,
-          bottom: 5,
-          left: 5,
-          right: 5,
-          background: { r: 255, g: 255, b: 255 },
-        })
         .png()
         .toBuffer();
 
-      const mainLeft = Math.floor((width - diameter) / 2) - 5;
-      const mainTop = Math.floor((height - diameter) / 2) - 5;
+      const borderSvg = Buffer.from(
+        `<svg width="${diameter + border * 2}" height="${
+          diameter + border * 2
+        }"><circle cx="${(diameter + border * 2) / 2}" cy="${
+          (diameter + border * 2) / 2
+        }" r="${diameter / 2 + border}" fill="white" /></svg>`,
+      );
+
+      const mainCircle = await sharp(borderSvg)
+        .composite([{ input: baseCircle, left: border, top: border }])
+        .png()
+        .toBuffer();
+
+      const mainLeft = Math.floor((width - (diameter + border * 2)) / 2);
+      const mainTop = Math.floor((height - (diameter + border * 2)) / 2);
 
       composite.push({ input: mainCircle, left: mainLeft, top: mainTop });
 


### PR DESCRIPTION
## Summary
- adjust special circle collage function to create a circular white border

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880e127cd70832b8deadbfe4f95770d