### PR TITLE
Include caption in image descriptions

### DIFF
--- a/docs/2025-07-16.image-description.md
+++ b/docs/2025-07-16.image-description.md
@@ -25,6 +25,7 @@ npx prisma migrate dev --name add_image_description
    - Downloaded from Telegram
    - Uploaded to your storage service (AWS S3)
    - Sent to OpenAI's API for description
+     (the photo caption is included in the prompt if present)
    - The description is saved to the database
    - The description is returned to the user in the chat
 

--- a/src/services/llm.service.ts
+++ b/src/services/llm.service.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '@nestjs/config';
 export class LlmService {
   constructor(private readonly configService: ConfigService) {}
 
-  async describeImage(imageBuffer: Buffer): Promise<string> {
+  async describeImage(imageBuffer: Buffer, comment?: string): Promise<string> {
     try {
       const apiKey = this.configService.get<string>('OPENAI_API_KEY');
       if (!apiKey) {
@@ -36,8 +36,11 @@ export class LlmService {
                       'Опиши что видишь на изображении, включая объекты, людей, действия, и контекст.',
                       'Попробуй сделать описание, так чтобы его можно было использовать в журнальной статье.',
                       'Не используй слова "фотография" или "изображение" и вводных конструкций, сразу описывай что видишь.',
-                      'Не делай обобщений о настроении или назначении изображения',
-                    ].join(' '),
+                      'Не делай обобщений о настроении или назначении изображения.',
+                      comment ? `Комментарий пользователя: ${comment}` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(' '),
                   },
                   {
                     type: 'image_url',

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -418,7 +418,10 @@ export class TelegramBotService {
       );
 
       // Get image description from LLM
-      const imageDescription = await this.llmService.describeImage(photoBuffer);
+      const imageDescription = await this.llmService.describeImage(
+        photoBuffer,
+        caption,
+      );
 
       const { date: noteDate, cleanContent } =
         this.dateParser.extractDateFromFirstLine(caption || '');


### PR DESCRIPTION
## Summary
- pass an optional comment to `LlmService.describeImage`
- include photo captions in prompts when describing images
- mention caption support in image description docs

## Testing
- `npm run lint`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68821ffb2f64832ba2a74550a896d6b2