### PR TITLE
Update /tl list to single message

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Example:
 
 ### `/tl`
 
-Lists unfinished todo items. You can filter by the same `@tag`, `.context` and `!project` tokens as in `/task`.
+Lists unfinished todo items in a single message. Each task has an inline button
+showing its key so you can quickly start editing. You can filter by the same
+`@tag`, `.context` and `!project` tokens as in `/task`.
 
 Example:
 

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -390,19 +390,21 @@ export class TaskCommandsService {
       return;
     }
 
+    const lines: string[] = [];
+    const buttons: { text: string; callback_data: string }[][] = [];
+
     for (const t of latestTasks) {
-      let line = `${t.key} ${t.content}`;
+      let line = `${t.content}`;
       if (t.dueDate) {
         line += ` (due: ${format(t.dueDate, 'MMM d, yyyy HH:mm')})`;
       }
-      await ctx.reply(line, {
-        reply_markup: {
-          inline_keyboard: [
-            [{ text: 'Edit', callback_data: `edit_task_${t.key}` }],
-          ],
-        },
-      });
+      lines.push(line);
+      buttons.push([{ text: t.key, callback_data: `edit_task_${t.key}` }]);
     }
+
+    await ctx.reply(lines.join('\n'), {
+      reply_markup: { inline_keyboard: buttons },
+    });
   }
 
   isEditing(chatId: number): boolean {


### PR DESCRIPTION
## Summary
- list all tasks from `/tl` in one message
- show task keys as inline buttons
- document updated `/tl` behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68823ed1dec8832b9963995b5c63f6aa