### PR TITLE
Add due date icons in /tl output

### DIFF
--- a/src/telegram-bot/task-commands.service.spec.ts
+++ b/src/telegram-bot/task-commands.service.spec.ts
@@ -320,5 +320,84 @@ describe('TaskCommandsService', () => {
         expect.stringContaining('ORDER BY "dueDate" IS NULL, "dueDate" ASC'),
       );
     });
+
+    it('should add icons for tasks with due dates', async () => {
+      const now = new Date();
+      const past = new Date(now.getTime() - 86400000);
+      const today = new Date(now);
+      today.setHours(23, 59, 0, 0);
+      const future = new Date(now.getTime() + 86400000 * 2);
+
+      const mockPrisma = {
+        $queryRawUnsafe: jest.fn().mockResolvedValue([
+          {
+            id: 1,
+            key: 'T-1',
+            content: 'Past',
+            createdAt: past,
+            status: 'new',
+            completedAt: null,
+            priority: null,
+            dueDate: past,
+            snoozedUntil: null,
+            tags: [],
+            contexts: [],
+            projects: [],
+          },
+          {
+            id: 2,
+            key: 'T-2',
+            content: 'Today',
+            createdAt: now,
+            status: 'new',
+            completedAt: null,
+            priority: null,
+            dueDate: today,
+            snoozedUntil: null,
+            tags: [],
+            contexts: [],
+            projects: [],
+          },
+          {
+            id: 3,
+            key: 'T-3',
+            content: 'Future',
+            createdAt: now,
+            status: 'new',
+            completedAt: null,
+            priority: null,
+            dueDate: future,
+            snoozedUntil: null,
+            tags: [],
+            contexts: [],
+            projects: [],
+          },
+        ]),
+        todo: { count: jest.fn() },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          TaskCommandsService,
+          DateParserService,
+          { provide: PrismaService, useValue: mockPrisma },
+        ],
+      }).compile();
+
+      const svc = module.get<TaskCommandsService>(TaskCommandsService);
+      const mockReply = jest.fn();
+      const ctx: Context = {
+        message: { text: '/tl' },
+        chat: { id: 123456 },
+        reply: mockReply,
+      } as unknown as Context;
+
+      await svc.handleListCommand(ctx);
+
+      const replyText = mockReply.mock.calls[0][0] as string;
+      expect(replyText).toContain('❗');
+      expect(replyText).toContain('⏰');
+      expect(replyText).toContain('📅');
+    });
   });
 });

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Context } from 'telegraf';
 import { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 import { PrismaService } from '../prisma/prisma.service';
-import { format, startOfDay, endOfDay } from 'date-fns';
+import { format, startOfDay, endOfDay, isToday } from 'date-fns';
 import { DateParserService } from '../services/date-parser.service';
 
 interface ParsedTask {
@@ -394,8 +394,21 @@ export class TaskCommandsService {
     const buttons: { text: string; callback_data: string }[][] = [];
     let row: { text: string; callback_data: string }[] = [];
 
+    const now = new Date();
+
     for (const t of latestTasks) {
-      let line = `${t.key} ${t.content}`;
+      let prefix = '';
+      if (t.dueDate) {
+        let icon = '📅';
+        if (t.dueDate.getTime() < now.getTime()) {
+          icon = '❗';
+        } else if (isToday(t.dueDate)) {
+          icon = '⏰';
+        }
+        prefix = `${icon} `;
+      }
+
+      let line = `${prefix}${t.key} ${t.content}`;
       if (t.dueDate) {
         line += ` (due: ${format(t.dueDate, 'MMM d, yyyy HH:mm')})`;
       }


### PR DESCRIPTION
## Summary
- show icons for overdue, today and future tasks in `/tl` list
- test icon output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68839c8f98e8832b9fbe096b04d75454