### PR TITLE
Add task notes feature

### DIFF
--- a/prisma/migrations/20250726120000_add_task_notes/migration.sql
+++ b/prisma/migrations/20250726120000_add_task_notes/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "TaskNote" (
+    "id" SERIAL NOT NULL,
+    "key" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "chatId" BIGINT NOT NULL,
+
+    CONSTRAINT "TaskNote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TaskNote_key_idx" ON "TaskNote"("key");
+
+-- CreateIndex
+CREATE INDEX "TaskNote_chatId_idx" ON "TaskNote"("chatId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,3 +94,14 @@ model Answer {
   @@index([answerDate])
   @@index([createdAt])
 }
+
+model TaskNote {
+  id        Int      @id @default(autoincrement())
+  key       String
+  content   String   @db.Text
+  createdAt DateTime @default(now())
+  chatId    BigInt
+
+  @@index([key])
+  @@index([chatId])
+}

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -277,6 +277,8 @@ export class TelegramBotService {
       } else if (data && data.startsWith('edit_status_')) {
         const action = data.replace('edit_status_', '');
         await this.taskCommands.handleEditCallback(ctx, action);
+      } else if (data === 'edit_add_note') {
+        await this.taskCommands.handleEditCallback(ctx, 'add_note');
       }
     });
   }


### PR DESCRIPTION
## Summary
- create `TaskNote` table and migration
- show existing task notes in `/tl` editing screen
- add ability to add a note via inline button
- update tests for new feature

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6884ceb09158832b9043840eba26faf0