### PR TITLE
Implement task editing via Telegraf scenes

### DIFF
--- a/src/telegram-bot/scenes/task-edit.scene.ts
+++ b/src/telegram-bot/scenes/task-edit.scene.ts
@@ -1,0 +1,200 @@
+import { Scenes, Context } from 'telegraf';
+import { CallbackQuery } from 'telegraf/typings/core/types/typegram';
+import { TaskCommandsService } from '../task-commands.service';
+
+export interface TaskEditWizardContext extends Context {
+  scene: Scenes.SceneContextScene<
+    TaskEditWizardContext,
+    Scenes.WizardSessionData
+  >;
+  wizard: Scenes.WizardContextWizard<TaskEditWizardContext>;
+}
+
+export function createTaskEditScene(taskService: TaskCommandsService) {
+  return new Scenes.WizardScene<TaskEditWizardContext>(
+    'taskEditScene',
+    async (ctx) => {
+      const key = (ctx.scene.state as { key: string }).key;
+      (ctx.wizard.state as { key?: string }).key = key;
+      await ctx.answerCbQuery?.();
+      await (
+        ctx as TaskEditWizardContext & {
+          editMessageReplyMarkup?: (markup: any) => Promise<void>;
+        }
+      ).editMessageReplyMarkup?.(undefined);
+      await ctx.reply(`Choose action for ${key}`, {
+        reply_markup: {
+          inline_keyboard: [
+            [
+              { text: 'Done', callback_data: 'status_done' },
+              { text: 'Canceled', callback_data: 'status_canceled' },
+              { text: 'Snooze', callback_data: 'status_snooze' },
+            ],
+            [
+              { text: 'Edit', callback_data: 'action_edit' },
+              { text: 'Note', callback_data: 'action_note' },
+              { text: 'Image', callback_data: 'action_image' },
+            ],
+            [{ text: 'Cancel', callback_data: 'cancel' }],
+          ],
+        },
+      });
+      return ctx.wizard.next();
+    },
+    async (ctx) => {
+      const data = (ctx.callbackQuery as CallbackQuery.DataQuery | undefined)
+        ?.data;
+      const key = (ctx.wizard.state as { key: string }).key;
+      if (!data) return;
+      if (data === 'cancel') {
+        await ctx.scene.leave();
+        return;
+      }
+      if (data === 'status_done' || data === 'status_canceled') {
+        await (taskService as any).editTask(ctx, key, {
+          content: '',
+          tags: [],
+          contexts: [],
+          projects: [],
+          status: data === 'status_done' ? 'done' : 'canceled',
+        });
+        await ctx.scene.leave();
+        return;
+      }
+      if (data === 'status_snooze') {
+        await ctx.reply('How many days to snooze?');
+        return ctx.wizard.selectStep(2);
+      }
+      if (data === 'action_edit') {
+        const chatId = ctx.chat?.id;
+        if (chatId) {
+          const latest = await (taskService as any).prisma.todo.findFirst({
+            where: { key, chatId },
+            orderBy: { createdAt: 'desc' },
+            include: { images: true },
+          });
+          if (latest) {
+            let text = `${latest.key} ${latest.content}`;
+            if (latest.priority) text += ` (${latest.priority})`;
+            if (latest.dueDate)
+              text += `\nDue: ${latest.dueDate.toISOString()}`;
+            if (latest.tags.length) text += `\nTags: ${latest.tags.join(', ')}`;
+            if (latest.contexts.length)
+              text += `\nContexts: ${latest.contexts.join(', ')}`;
+            if (latest.projects.length)
+              text += `\nProjects: ${latest.projects.join(', ')}`;
+            await ctx.reply(text, {
+              reply_markup: {
+                inline_keyboard: [
+                  [{ text: 'Cancel', callback_data: 'cancel' }],
+                ],
+              },
+            });
+            return ctx.wizard.selectStep(3);
+          }
+        }
+        await ctx.reply('Task not found');
+        await ctx.scene.leave();
+        return;
+      }
+      if (data === 'action_note') {
+        await ctx.reply('Waiting for a note', {
+          reply_markup: {
+            inline_keyboard: [[{ text: 'Cancel', callback_data: 'cancel' }]],
+          },
+        });
+        return ctx.wizard.selectStep(4);
+      }
+      if (data === 'action_image') {
+        await ctx.reply('Waiting for an image', {
+          reply_markup: {
+            inline_keyboard: [[{ text: 'Cancel', callback_data: 'cancel' }]],
+          },
+        });
+        return ctx.wizard.selectStep(5);
+      }
+    },
+    async (ctx) => {
+      if (
+        ctx.callbackQuery &&
+        (ctx.callbackQuery as CallbackQuery.DataQuery).data === 'cancel'
+      ) {
+        await ctx.scene.leave();
+        return;
+      }
+      if (!ctx.message || !('text' in ctx.message)) return;
+      const days = parseInt(ctx.message.text.trim(), 10);
+      if (Number.isNaN(days)) {
+        await ctx.reply('Please provide number of days');
+        return;
+      }
+      const key = (ctx.wizard.state as { key: string }).key;
+      const snoozedUntil = new Date();
+      snoozedUntil.setDate(snoozedUntil.getDate() + days);
+      await (taskService as any).editTask(ctx, key, {
+        content: '',
+        tags: [],
+        contexts: [],
+        projects: [],
+        status: 'snoozed',
+        snoozedUntil,
+      });
+      await ctx.scene.leave();
+    },
+    async (ctx) => {
+      if (
+        ctx.callbackQuery &&
+        (ctx.callbackQuery as CallbackQuery.DataQuery).data === 'cancel'
+      ) {
+        await ctx.scene.leave();
+        return;
+      }
+      if (!ctx.message || !('text' in ctx.message)) return;
+      const key = (ctx.wizard.state as { key: string }).key;
+      const parsed = (taskService as any).parseTask(ctx.message.text.trim());
+      await (taskService as any).editTask(ctx, key, parsed);
+      await ctx.scene.leave();
+    },
+    async (ctx) => {
+      if (
+        ctx.callbackQuery &&
+        (ctx.callbackQuery as CallbackQuery.DataQuery).data === 'cancel'
+      ) {
+        await ctx.scene.leave();
+        return;
+      }
+      if (!ctx.message || !('text' in ctx.message)) return;
+      const key = (ctx.wizard.state as { key: string }).key;
+      await (taskService as any).prisma.taskNote.create({
+        data: {
+          key,
+          content: ctx.message.text.trim(),
+          chatId: ctx.chat?.id || 0,
+        },
+      });
+      await ctx.reply('Note added');
+      await ctx.scene.leave();
+    },
+    async (ctx) => {
+      if (
+        ctx.callbackQuery &&
+        (ctx.callbackQuery as CallbackQuery.DataQuery).data === 'cancel'
+      ) {
+        await ctx.scene.leave();
+        return;
+      }
+      if (!ctx.message || !('photo' in ctx.message)) return;
+      const key = (ctx.wizard.state as { key: string }).key;
+      const images = await (taskService as any).processTaskImages(ctx);
+      if (images.length > 0) {
+        await (taskService as any).editTask(
+          ctx,
+          key,
+          { content: '', tags: [], contexts: [], projects: [] },
+          images,
+        );
+      }
+      await ctx.scene.leave();
+    },
+  );
+}

--- a/src/telegram-bot/scenes/task-edit.scene.ts
+++ b/src/telegram-bot/scenes/task-edit.scene.ts
@@ -121,6 +121,7 @@ export function createTaskEditScene(taskService: TaskCommandsService) {
         ctx.callbackQuery &&
         (ctx.callbackQuery as CallbackQuery.DataQuery).data === 'cancel'
       ) {
+        await ctx.answerCbQuery?.();
         await ctx.scene.leave();
         return;
       }

--- a/src/telegram-bot/scenes/task-edit.scene.ts
+++ b/src/telegram-bot/scenes/task-edit.scene.ts
@@ -160,16 +160,23 @@ export function createTaskEditScene(taskService: TaskCommandsService) {
         ctx.callbackQuery &&
         (ctx.callbackQuery as CallbackQuery.DataQuery).data === 'cancel'
       ) {
+        await ctx.answerCbQuery?.();
         await ctx.scene.leave();
         return;
       }
       if (!ctx.message || !('text' in ctx.message)) return;
       const key = (ctx.wizard.state as { key: string }).key;
+      const chatId = ctx.chat?.id;
+      if (!chatId) {
+        await ctx.reply('Error: Chat ID not available');
+        await ctx.scene.leave();
+        return;
+      }
       await (taskService as any).prisma.taskNote.create({
         data: {
           key,
           content: ctx.message.text.trim(),
-          chatId: ctx.chat?.id || 0,
+          chatId,
         },
       });
       await ctx.reply('Note added');
@@ -180,6 +187,7 @@ export function createTaskEditScene(taskService: TaskCommandsService) {
         ctx.callbackQuery &&
         (ctx.callbackQuery as CallbackQuery.DataQuery).data === 'cancel'
       ) {
+        await ctx.answerCbQuery?.();
         await ctx.scene.leave();
         return;
       }

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -29,7 +29,10 @@ export class TaskCommandsService {
 
   private readonly editSessions: Map<
     number,
-    { key: string; step: 'await_action' | 'await_snooze_days' | 'await_note' | 'await_image' }
+    {
+      key: string;
+      step: 'await_action' | 'await_snooze_days' | 'await_note' | 'await_image';
+    }
   > = new Map();
 
   async handleTaskCommand(ctx: Context) {
@@ -532,50 +535,7 @@ export class TaskCommandsService {
   }
 
   async startEditConversation(ctx: Context, key: string) {
-    const chatId = ctx.chat?.id || ctx.from?.id;
-    if (!chatId) return;
-    this.editSessions.set(chatId, { key, step: 'await_action' });
-    await ctx.answerCbQuery?.();
-    await (
-      ctx as Context & {
-        editMessageReplyMarkup?: (
-          markup: InlineKeyboardMarkup | undefined,
-        ) => Promise<void>;
-      }
-    ).editMessageReplyMarkup?.(undefined);
-
-    // Get the latest task with images
-    const latestTask = await this.prisma.todo.findFirst({
-      where: { key, chatId },
-      orderBy: { createdAt: 'desc' },
-      include: { images: true },
-    });
-
-    const notes = await this.prisma.taskNote.findMany({
-      where: { key, chatId },
-      orderBy: { createdAt: 'asc' },
-    });
-    const noteLines = notes.map((n) => `- ${n.content}`).join('\n');
-    let text = `Editing ${key}. Send updates or choose status`;
-    if (notes.length) {
-      text += `\n\nNotes:\n${noteLines}`;
-    }
-    if (latestTask?.images && latestTask.images.length > 0) {
-      text += `\n\nImages: ${latestTask.images.length}`;
-    }
-    await ctx.reply(text, {
-      reply_markup: {
-        inline_keyboard: [
-          [
-            { text: 'Done', callback_data: 'edit_status_done' },
-            { text: 'Canceled', callback_data: 'edit_status_canceled' },
-          ],
-          [{ text: 'Snooze', callback_data: 'edit_status_snoozed' }],
-          [{ text: 'Add task note', callback_data: 'edit_add_todo_note' }],
-          [{ text: 'Add image', callback_data: 'edit_add_todo_image' }],
-        ],
-      },
-    });
+    await (ctx as any).scene?.enter?.('taskEditScene', { key });
   }
 
   async handleEditCallback(ctx: Context, action: string) {

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -119,7 +119,7 @@ export class TaskCommandsService {
     return Buffer.from(await response.arrayBuffer());
   }
 
-  private async processTaskImages(
+  public async processTaskImages(
     ctx: Context,
   ): Promise<{ url: string; description: string }[]> {
     const images: { url: string; description: string }[] = [];
@@ -158,6 +158,24 @@ export class TaskCommandsService {
     }
 
     return images;
+  }
+
+  public async getLatestTask(key: string, chatId: number) {
+    return this.prisma.todo.findFirst({
+      where: { key, chatId },
+      orderBy: { createdAt: 'desc' },
+      include: { images: true },
+    });
+  }
+
+  public async createTaskNote(key: string, content: string, chatId: number) {
+    return this.prisma.taskNote.create({
+      data: {
+        key,
+        content,
+        chatId,
+      },
+    });
   }
 
   private parseFilters(text: string): {
@@ -202,7 +220,7 @@ export class TaskCommandsService {
     return { tags, contexts, projects, remaining };
   }
 
-  private parseTask(text: string): ParsedTask {
+  public parseTask(text: string): ParsedTask {
     const { tags, contexts, projects, remaining } = this.parseFilters(text);
     const tokens = remaining;
     let priority: string | undefined;
@@ -347,7 +365,7 @@ export class TaskCommandsService {
     return undefined;
   }
 
-  private async editTask(
+  public async editTask(
     ctx: Context,
     key: string,
     updates: ParsedTask,


### PR DESCRIPTION
## Summary
- add `taskEditScene` wizard for editing todo items with Done/Canceled/Snooze/Edit/Note/Image actions
- register a Telegraf stage and middleware
- trigger scene when todo button is pressed
- update test to cover new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f2e60940832b8f5b0a459c5b034c