### PR TITLE
Improve todo page images and notes

### DIFF
--- a/src/telegram-bot/scenes/task-edit.scene.ts
+++ b/src/telegram-bot/scenes/task-edit.scene.ts
@@ -37,7 +37,7 @@ export function createTaskEditScene(taskService: TaskCommandsService) {
             text += `\nProjects: ${latest.projects.join(', ')}`;
           await ctx.reply(text);
           for (const img of latest.images) {
-            await ctx.replyWithPhoto(img.url, {
+            await ctx.replyWithDocument(img.url, {
               caption: img.description || undefined,
             });
           }

--- a/src/telegram-bot/task-history-commands.service.spec.ts
+++ b/src/telegram-bot/task-history-commands.service.spec.ts
@@ -10,12 +10,17 @@ describe('TaskHistoryCommandsService', () => {
     todo: {
       findMany: jest.fn(),
     },
+    taskNote: {
+      findMany: jest.fn(),
+    },
   };
   const mockStorageService = {
     uploadFileWithKey: jest.fn(),
   };
 
   beforeEach(async () => {
+    mockPrismaService.todo.findMany.mockReset();
+    mockPrismaService.taskNote.findMany.mockReset();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TaskHistoryCommandsService,
@@ -40,6 +45,7 @@ describe('TaskHistoryCommandsService', () => {
       reply: mockReply,
     } as unknown as Context;
     mockPrismaService.todo.findMany.mockResolvedValue([]);
+    mockPrismaService.taskNote.findMany.mockResolvedValue([]);
     await service.handleTaskHistoryCommand(ctx);
     expect(mockReply).toHaveBeenCalledWith('No tasks found in this chat');
   });


### PR DESCRIPTION
## Summary
- show attached images at full quality when editing tasks
- include notes and images in tasks HTML export
- adjust task history service tests

## Testing
- `npm test`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68893a1b0db0832ba1338e359908bdf9