### PR TITLE
Send todo images as photos

### DIFF
--- a/src/telegram-bot/scenes/task-edit.scene.ts
+++ b/src/telegram-bot/scenes/task-edit.scene.ts
@@ -1,5 +1,8 @@
 import { Scenes, Context } from 'telegraf';
-import { CallbackQuery } from 'telegraf/typings/core/types/typegram';
+import {
+  CallbackQuery,
+  InlineKeyboardMarkup,
+} from 'telegraf/typings/core/types/typegram';
 import { TaskCommandsService } from '../task-commands.service';
 
 export interface TaskEditWizardContext extends Context {
@@ -19,7 +22,9 @@ export function createTaskEditScene(taskService: TaskCommandsService) {
       await ctx.answerCbQuery?.();
       await (
         ctx as TaskEditWizardContext & {
-          editMessageReplyMarkup?: (markup: any) => Promise<void>;
+          editMessageReplyMarkup?: (
+            markup: InlineKeyboardMarkup | undefined,
+          ) => Promise<void>;
         }
       ).editMessageReplyMarkup?.(undefined);
       const chatId = ctx.chat?.id;
@@ -37,7 +42,7 @@ export function createTaskEditScene(taskService: TaskCommandsService) {
             text += `\nProjects: ${latest.projects.join(', ')}`;
           await ctx.reply(text);
           for (const img of latest.images) {
-            await ctx.replyWithDocument(img.url, {
+            await ctx.replyWithPhoto(img.url, {
               caption: img.description || undefined,
             });
           }

--- a/src/telegram-bot/task-commands.service.ts
+++ b/src/telegram-bot/task-commands.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Context } from 'telegraf';
 import { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+import { TaskEditWizardContext } from './scenes/task-edit.scene';
 import { PrismaService } from '../prisma/prisma.service';
 import { format, startOfDay, endOfDay, isToday } from 'date-fns';
 import { DateParserService } from '../services/date-parser.service';
@@ -568,7 +569,9 @@ export class TaskCommandsService {
   }
 
   async startEditConversation(ctx: Context, key: string) {
-    await (ctx as any).scene?.enter?.('taskEditScene', { key });
+    await (ctx as TaskEditWizardContext).scene?.enter?.('taskEditScene', {
+      key,
+    });
   }
 
   async handleEditCallback(ctx: Context, action: string) {


### PR DESCRIPTION
## Summary
- show todo images as regular photos instead of documents
- allow `startEditConversation` to use correct scene context

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a395bc130832bb3c393b62d5b4972