### PR TITLE
feat(mini-app): add todo list with task details

### DIFF
--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -192,6 +192,7 @@ describe('TelegramBotService', () => {
     const svc = service as unknown as { getHelpMessage(): string };
     const result = svc.getHelpMessage();
     const expected = [
+      '/a - Open Mini App',
       '/c or /collage - Create image collage',
       '/d or /dairy - Dairy Notes',
       '/help - Show this help message',

--- a/web/mini-app/src/App.tsx
+++ b/web/mini-app/src/App.tsx
@@ -11,6 +11,13 @@ type UserData = {
   counts: Counts;
 };
 
+type TaskSummary = { key: string; content: string; dueDate: string | null };
+type TaskDetails = {
+  todo: { key: string; content: string; dueDate: string | null };
+  notes: { id: number; content: string }[];
+  images: { id: number; url: string; description?: string | null }[];
+};
+
 function getInitDataString(): string {
   return window.Telegram?.WebApp?.initData || '';
 }
@@ -20,6 +27,8 @@ export default function App() {
 
   const [user, setUser] = useState<UserData | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [tasks, setTasks] = useState<TaskSummary[]>([]);
+  const [selected, setSelected] = useState<TaskDetails | null>(null);
 
   useEffect(() => {
     const initData = rawInitData ?? getInitDataString();
@@ -47,6 +56,57 @@ export default function App() {
       cancelled = true;
     };
   }, [rawInitData]);
+
+  useEffect(() => {
+    if (!user) return;
+    const initData = rawInitData ?? getInitDataString();
+    const url = `/mini-app-api/todos?initData=${encodeURIComponent(initData)}`;
+    let cancelled = false;
+    fetch(url)
+      .then((r) => r.json())
+      .then((data: unknown) => {
+        if (cancelled) return;
+        if (Array.isArray(data)) {
+          setTasks(
+            data.map((t) => ({
+              key: t.key,
+              content: t.content,
+              dueDate: t.dueDate ? String(t.dueDate) : null,
+            })),
+          );
+        }
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user, rawInitData]);
+
+  const loadTask = (key: string) => {
+    const initData = rawInitData ?? getInitDataString();
+    const url = `/mini-app-api/todo?initData=${encodeURIComponent(
+      initData,
+    )}&key=${encodeURIComponent(key)}`;
+    fetch(url)
+      .then((r) => r.json())
+      .then((data: unknown) => {
+        if (data && typeof data === 'object' && 'todo' in data) {
+          const d = data as TaskDetails;
+          setSelected({
+            todo: {
+              key: d.todo.key,
+              content: d.todo.content,
+              dueDate: d.todo.dueDate ? String(d.todo.dueDate) : null,
+            },
+            notes: d.notes,
+            images: d.images,
+          });
+        }
+      })
+      .catch((e: unknown) => setError(String(e)));
+  };
 
   const textColor = 'var(--tg-theme-text-color)';
   const bgColor = 'var(--tg-theme-bg-color)';
@@ -113,6 +173,51 @@ export default function App() {
           )}
         </div>
       </div>
+      {tasks.length > 0 && (
+        <div style={{ marginTop: 16 }}>
+          {tasks.map((t) => (
+            <div key={t.key} style={{ marginBottom: 8 }}>
+              <button onClick={() => loadTask(t.key)}>{`${t.key}: ${t.content}`}</button>
+            </div>
+          ))}
+        </div>
+      )}
+      {selected && (
+        <div style={{ marginTop: 16 }}>
+          <h2>
+            {selected.todo.key} {selected.todo.content}
+          </h2>
+          {selected.todo.dueDate && (
+            <div>Due: {new Date(selected.todo.dueDate).toLocaleString()}</div>
+          )}
+          {selected.images.length > 0 && (
+            <div style={{ marginTop: 8 }}>
+              {selected.images.map((img) => (
+                <div key={img.id} style={{ marginBottom: 8 }}>
+                  <img src={img.url} style={{ maxWidth: '100%' }} />
+                  {img.description && <div>{img.description}</div>}
+                </div>
+              ))}
+            </div>
+          )}
+          {selected.notes.length > 0 && (
+            <div style={{ marginTop: 8 }}>
+              {selected.notes.map((n) => (
+                <pre
+                  key={n.id}
+                  style={{
+                    background: 'rgba(0,0,0,0.05)',
+                    padding: 8,
+                    whiteSpace: 'pre-wrap',
+                  }}
+                >
+                  {n.content}
+                </pre>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expose mini-app API endpoints to list todos and fetch task details
- serve stored task images and include per-image URLs in todo details
- adjust bot help message test for mini-app command

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899cc644434832ba6c6df099cabb8bc