### PR TITLE
feat: add multilingual translation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Example:
 /s zdravo
 ```
 
+### `/f`
+
+Translates a phrase between Russian, English and Serbian. Detects the input language and returns two translation variants for each of the other two languages. Only works in private chats.
+
+- **text** — phrase in Russian, English or Serbian.
+
+Example:
+
+```
+/f hello world
+```
+
 ### `/history`
 
 Generates an HTML page with all messages longer than 21 characters.

--- a/src/telegram-bot/foreign-commands.service.ts
+++ b/src/telegram-bot/foreign-commands.service.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { Context } from 'telegraf';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class ForeignCommandsService {
+  private readonly apiKey: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.apiKey = this.configService.get<string>('OPENAI_API_KEY') || '';
+    if (!this.apiKey) {
+      throw new Error('OPENAI_API_KEY is not defined');
+    }
+  }
+
+  async handleForeignCommand(ctx: Context) {
+    if (ctx.chat?.type !== 'private') {
+      await ctx.reply(
+        'Эта команда доступна только в личных сообщениях с ботом',
+      );
+      return;
+    }
+
+    const messageText = this.getCommandText(ctx);
+    if (!messageText) return;
+
+    const query = messageText.split(' ').slice(1).join(' ').trim();
+    if (!query) {
+      await ctx.reply('Пожалуйста, укажите фразу после команды');
+      return;
+    }
+
+    try {
+      console.log('Отправляем запрос к ChatGPT для перевода:', query);
+      await ctx.reply('Получаю перевод...');
+
+      const translation = await this.getTranslation(query);
+      console.log('Получен ответ от ChatGPT:', translation);
+
+      await ctx.reply(translation, { parse_mode: 'Markdown' });
+    } catch (error) {
+      console.error('Error handling foreign translation:', error);
+      await ctx.reply('Произошла ошибка при получении перевода');
+    }
+  }
+
+  private getCommandText(ctx: Context): string | undefined {
+    if ('message' in ctx && ctx.message && 'text' in ctx.message) {
+      return ctx.message.text;
+    }
+    if ('channelPost' in ctx && ctx.channelPost && 'text' in ctx.channelPost) {
+      return ctx.channelPost.text;
+    }
+    return undefined;
+  }
+
+  private async getTranslation(text: string): Promise<string> {
+    const prompt = this.createPrompt(text);
+
+    try {
+      const response = await fetch(
+        'https://api.openai.com/v1/chat/completions',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: 'gpt-5-mini',
+            messages: [
+              {
+                role: 'user',
+                content: prompt,
+              },
+            ],
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('OpenAI API error:', response.status, errorText);
+        throw new Error(`OpenAI API error: ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as {
+        choices: {
+          message: {
+            content: string;
+          };
+        }[];
+      };
+      return data.choices[0].message.content;
+    } catch (error) {
+      console.error('Error in getTranslation:', error);
+      throw error;
+    }
+  }
+
+  private createPrompt(text: string): string {
+    return `Detect whether the following phrase is in Russian, English, or Serbian. Translate it into the other two languages, providing two translation variants for each target language. Format the answer in Markdown as:
+
+- Detected language: <language>
+- <Target language 1>:
+  1. first variant
+  2. second variant
+- <Target language 2>:
+  1. first variant
+  2. second variant
+
+Phrase: "${text}"`;
+  }
+}

--- a/src/telegram-bot/telegram-bot.module.ts
+++ b/src/telegram-bot/telegram-bot.module.ts
@@ -7,6 +7,7 @@ import { ServicesModule } from '../services/services.module';
 import { DairyCommandsService } from './dairy-commands.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { SerbianCommandsService } from './serbian-commands.service';
+import { ForeignCommandsService } from './foreign-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
 import { TaskHistoryCommandsService } from './task-history-commands.service';
@@ -21,6 +22,7 @@ import { QaCommandsService } from './qa-commands.service';
     DairyCommandsService,
     PrismaService,
     SerbianCommandsService,
+    ForeignCommandsService,
     HistoryCommandsService,
     TaskCommandsService,
     TaskHistoryCommandsService,

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -7,6 +7,7 @@ import { DairyCommandsService } from './dairy-commands.service';
 import { StorageService } from '../services/storage.service';
 import { LlmService } from '../services/llm.service';
 import { SerbianCommandsService } from './serbian-commands.service';
+import { ForeignCommandsService } from './foreign-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
 import { TaskHistoryCommandsService } from './task-history-commands.service';
@@ -120,6 +121,12 @@ describe('TelegramBotService', () => {
           },
         },
         {
+          provide: ForeignCommandsService,
+          useValue: {
+            handleForeignCommand: jest.fn(),
+          },
+        },
+        {
           provide: HistoryCommandsService,
           useValue: {
             handleHistoryCommand: jest.fn(),
@@ -195,6 +202,7 @@ describe('TelegramBotService', () => {
       '/a - Open Mini App',
       '/c or /collage - Create image collage',
       '/d or /dairy - Dairy Notes',
+      '/f - Translate between RU/EN/SR',
       '/help - Show this help message',
       '/history - Chat History',
       '/q - Answer questions',

--- a/src/telegram-bot/telegram-bot.service.ts
+++ b/src/telegram-bot/telegram-bot.service.ts
@@ -16,6 +16,7 @@ import { DairyCommandsService } from './dairy-commands.service';
 import { StorageService } from '../services/storage.service';
 import { LlmService } from '../services/llm.service';
 import { SerbianCommandsService } from './serbian-commands.service';
+import { ForeignCommandsService } from './foreign-commands.service';
 import { HistoryCommandsService } from './history-commands.service';
 import { TaskCommandsService } from './task-commands.service';
 import { TaskHistoryCommandsService } from './task-history-commands.service';
@@ -48,6 +49,7 @@ export class TelegramBotService {
     private readonly storageService: StorageService,
     private readonly llmService: LlmService,
     private readonly serbianCommands: SerbianCommandsService,
+    private readonly foreignCommands: ForeignCommandsService,
     private readonly historyCommands: HistoryCommandsService,
     private readonly taskCommands: TaskCommandsService,
     private readonly taskHistoryCommands: TaskHistoryCommandsService,
@@ -136,6 +138,12 @@ export class TelegramBotService {
     this.bot.command(['s'], (ctx) => {
       console.log('Получена команда /s:', ctx.message?.text);
       return this.serbianCommands.handleSerbianCommand(ctx);
+    });
+
+    // Add the new foreign translation command
+    this.bot.command(['f'], (ctx) => {
+      console.log('Получена команда /f:', ctx.message?.text);
+      return this.foreignCommands.handleForeignCommand(ctx);
     });
 
     // Add the new history command
@@ -721,6 +729,7 @@ export class TelegramBotService {
       { name: '/d or /dairy', description: 'Dairy Notes' },
       { name: '/history', description: 'Chat History' },
       { name: '/s', description: 'Serbian Translation' },
+      { name: '/f', description: 'Translate between RU/EN/SR' },
       { name: '/t or /task', description: 'Create Todo item' },
       { name: '/tl', description: 'List Todo items' },
       { name: '/th', description: 'Tasks HTML export' },


### PR DESCRIPTION
## Summary
- add `/f` command for language detection and translation between Russian, English and Serbian
- register new command in Telegram bot and help message
- document usage of `/f`

## Testing
- `npm run lint`
- `npm test` *(fails: OPENAI_API_KEY is not defined / network errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a59bbd463c832b93807e59de30723a